### PR TITLE
Add max width for Repository selector

### DIFF
--- a/apps/frontend/components/repository/Outline/CopyActivity/index.vue
+++ b/apps/frontend/components/repository/Outline/CopyActivity/index.vue
@@ -30,6 +30,7 @@
         :items="repositories"
         :label="schema.name"
         :loading="isFetchingRepositories"
+        :menu-props="{ maxWidth: '100%' }"
         :model-value="selectedRepository"
         item-title="name"
         item-value="id"

--- a/packages/core-components/src/components/SelectElement/SelectRepository.vue
+++ b/packages/core-components/src/components/SelectElement/SelectRepository.vue
@@ -2,6 +2,7 @@
   <VAutocomplete
     :items="repositories"
     :loading="loading"
+    :menu-props="{ maxWidth: '100%' }"
     :model-value="repository"
     item-title="name"
     item-value="id"


### PR DESCRIPTION
Adds max-width prop to the menu for repository selector upon copying activities or content elements