### PR TITLE
Tweak Revisions page and History tab

### DIFF
--- a/apps/frontend/app/components/editor/Sidebar/index.vue
+++ b/apps/frontend/app/components/editor/Sidebar/index.vue
@@ -28,18 +28,28 @@
           <VTab
             v-for="tab in tabs"
             :key="tab.name"
-            v-tooltip:bottom="
-              compact ? { text: tab.label, openDelay: 500 } : undefined
-            "
             :aria-label="tab.label"
             :disabled="tab.disabled"
             :value="tab.name"
             :variant="selectedTab === tab.name ? 'tonal' : 'text'"
-            class="mr-1"
             rounded="pill"
           >
-            <VIcon v-if="compact" :icon="`mdi-${tab.icon}`" />
+            <template v-if="compact">
+              <VIcon :icon="`mdi-${tab.icon}`" :start="selectedTab === tab.name" />
+              <VExpandXTransition>
+                <span v-if="selectedTab === tab.name" class="tab-label">
+                  {{ tab.label }}
+                </span>
+              </VExpandXTransition>
+            </template>
             <template v-else>{{ tab.label }}</template>
+            <VTooltip
+              v-if="compact && selectedTab !== tab.name"
+              :open-delay="500"
+              :text="tab.label"
+              activator="parent"
+              location="bottom"
+            />
             <template v-if="tab.badgeData" #append>
               <VBadge :content="tab.badgeData" color="tertiary" inline />
             </template>
@@ -275,6 +285,16 @@ watch(
     letter-spacing: 0.01em;
     text-transform: none;
   }
+
+  // Smooth the gap between the icon and the label as the active tab expands.
+  :deep(.v-tab .v-icon) {
+    transition: margin 0.2s ease;
+  }
+}
+
+// Keep the label on one line so its width animates cleanly during the expand.
+.tab-label {
+  white-space: nowrap;
 }
 
 .sidebar-collapse-btn {
@@ -302,10 +322,6 @@ watch(
   :deep(.v-window__container) {
     height: 100%;
     overflow: visible;
-  }
-
-  :deep(.v-window-item) {
-    padding-bottom: 4rem;
   }
 
   :deep(.activity-discussion) {

--- a/apps/frontend/app/components/repository/Revisions/ActivityHistory.vue
+++ b/apps/frontend/app/components/repository/Revisions/ActivityHistory.vue
@@ -16,11 +16,13 @@
         color="tertiary"
         density="compact"
         bg-color="transparent"
-        class="pa-0"
+        class="history-list pa-0"
         nav
       >
         <template v-for="group in groupedRevisions" :key="group.key">
-          <VListSubheader class="text-label-medium text-uppercase">
+          <VListSubheader
+            class="history-day-header text-label-medium text-uppercase"
+          >
             {{ group.label }}
           </VListSubheader>
           <template v-for="bundle in group.items" :key="bundle.uid">
@@ -68,9 +70,7 @@
 
 <script lang="ts" setup>
 import { findIndex, findLastIndex, last, map, uniqBy } from 'lodash-es';
-import { formatDate, useIntersectionObserver } from '@vueuse/core';
-import { isToday } from 'date-fns/isToday';
-import { isYesterday } from 'date-fns/isYesterday';
+import { useIntersectionObserver } from '@vueuse/core';
 import { Revision as RevisionEvents } from '@tailor-cms/common/src/sse.js';
 import { Entity } from '@tailor-cms/interfaces/revision';
 import type { Activity } from '@tailor-cms/interfaces/activity';
@@ -80,7 +80,7 @@ import { TailorEmptyState } from '@tailor-cms/core-components';
 
 import HistoryListItem from './HistoryListItem.vue';
 import { api } from '@/api';
-import { isSameRun, type HistoryEntry } from '@/lib/revision';
+import { groupByDay, isSameRun, type HistoryEntry } from '@/lib/revision';
 import sseRepositoryFeed from '@/lib/RepositoryFeed';
 import { useActivityStore } from '@/stores/activity';
 import { useEditorStore } from '@/stores/editor';
@@ -127,30 +127,7 @@ const bundledRevisions = computed<BundledRevision[]>(() => {
   return result;
 });
 
-const dayLabel = (date: Date) => {
-  if (isToday(date)) return 'Today';
-  if (isYesterday(date)) return 'Yesterday';
-  return formatDate(date, 'MMMM Do, YYYY');
-};
-
-interface RevisionDayGroup {
-  key: string;
-  label: string;
-  items: BundledRevision[];
-}
-
-// Group bundles by calendar day; one linear pass works because the list is DESC.
-const groupedRevisions = computed<RevisionDayGroup[]>(() => {
-  const groups: RevisionDayGroup[] = [];
-  for (const bundle of bundledRevisions.value) {
-    const date = new Date(bundle.createdAt);
-    const key = formatDate(date, 'YYYY-MM-DD');
-    const current = last(groups);
-    if (current?.key === key) current.items.push(bundle);
-    else groups.push({ key, label: dayLabel(date), items: [bundle] });
-  }
-  return groups;
-});
+const groupedRevisions = computed(() => groupByDay(bundledRevisions.value));
 
 const publishedRevision = computed<BundledRevision | undefined>(() => {
   const { publishedAt } = props.activity;
@@ -233,5 +210,18 @@ onBeforeUnmount(() =>
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
+}
+
+// VList defaults to overflow:auto, which would trap the sticky day headers;
+// clear it so they resolve to the scrolling .sidebar-content.
+.history-list {
+  overflow: visible;
+}
+
+.history-day-header {
+  background: rgb(var(--v-theme-surface-container-low));
+  position: sticky;
+  top: 0;
+  z-index: 1;
 }
 </style>

--- a/apps/frontend/app/components/repository/Revisions/EntityRevisions.vue
+++ b/apps/frontend/app/components/repository/Revisions/EntityRevisions.vue
@@ -1,5 +1,5 @@
 <template>
-  <VSheet class="rounded-b-xl" color="surface-raised" min-height="300">
+  <VSheet class="rounded-b-lg" color="surface-raised" min-height="300">
     <VRow class="pa-4" density="comfortable">
       <VCol cols="12" md="8" sm="7">
         <VSheet v-if="selectedRevision" rounded="lg" theme="light" border>

--- a/apps/frontend/app/components/repository/Revisions/EntityRevisions.vue
+++ b/apps/frontend/app/components/repository/Revisions/EntityRevisions.vue
@@ -1,15 +1,15 @@
 <template>
-  <VSheet class="rounded-b-lg" color="surface-container" min-height="300">
-    <VRow class="ma-0 pa-6">
+  <VSheet class="rounded-b-xl" color="surface-raised" min-height="300">
+    <VRow class="pa-4" density="comfortable">
       <VCol cols="12" md="8" sm="7">
-        <VSheet v-if="selectedRevision" rounded="lg" theme="light">
+        <VSheet v-if="selectedRevision" rounded="lg" theme="light" border>
           <ContentElementWrapper
             :element="selectedRevision?.state as unknown as ContentElement"
             is-disabled
           />
         </VSheet>
       </VCol>
-      <VCol cols="12" md="4" sm="5">
+      <VCol class="order-first order-sm-last" cols="12" md="4" sm="5">
         <EntitySidebar
           ref="sidebar"
           :is-detached="isDetached"

--- a/apps/frontend/app/components/repository/Revisions/EntityRevisions.vue
+++ b/apps/frontend/app/components/repository/Revisions/EntityRevisions.vue
@@ -1,8 +1,8 @@
 <template>
-  <VSheet class="rounded-b-lg" color="surface-raised" min-height="300">
+  <VSheet class="rounded-b-lg" color="surface-container" min-height="274">
     <VRow class="pa-4" density="comfortable">
       <VCol cols="12" md="8" sm="7">
-        <VSheet v-if="selectedRevision" rounded="lg" theme="light" border>
+        <VSheet v-if="selectedRevision" rounded="lg" theme="light" elevation="1">
           <ContentElementWrapper
             :element="selectedRevision?.state as unknown as ContentElement"
             is-disabled

--- a/apps/frontend/app/components/repository/Revisions/EntitySidebar.vue
+++ b/apps/frontend/app/components/repository/Revisions/EntitySidebar.vue
@@ -1,9 +1,9 @@
 <template>
-  <div class="changes-panel bg-surface-container-low rounded-lg">
+  <VSheet class="changes-panel" color="surface-container-low" rounded="lg">
     <VListSubheader class="changes-header border-b" color="text-medium-emphasis">
       Changes
     </VListSubheader>
-    <VList class="changes-list" bg-color="transparent" nav>
+    <VList class="changes-list py-0" bg-color="transparent">
       <VHover
         v-for="(revision, index) in revisions"
         :key="revision.id"
@@ -14,8 +14,8 @@
           :active="isSelected(revision)"
           :subtitle="revision.user?.label"
           :title="formatDate(revision)"
-          color="primary"
           class="position-relative"
+          lines="two"
           @click="$emit('preview', revision)"
         >
           <template v-if="isHovering" #append>
@@ -33,7 +33,7 @@
         </VListItem>
       </VHover>
     </VList>
-  </div>
+  </VSheet>
 </template>
 
 <script lang="ts" setup>
@@ -62,6 +62,8 @@ const formatDate = ({ createdAt }: Revision) => {
 
 <style lang="scss" scoped>
 .changes-panel {
+  --v-theme-overlay-multiplier: 0.8;
+
   display: flex;
   flex-direction: column;
   max-height: 32rem;
@@ -76,10 +78,6 @@ const formatDate = ({ createdAt }: Revision) => {
   flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;
-}
-
-.changes-list :deep(.v-list-item) {
-  overflow: hidden;
 }
 
 .v-progress-linear {

--- a/apps/frontend/app/components/repository/Revisions/EntitySidebar.vue
+++ b/apps/frontend/app/components/repository/Revisions/EntitySidebar.vue
@@ -1,5 +1,5 @@
 <template>
-  <VSheet class="changes-panel" color="surface-container-low" rounded="lg">
+  <VSheet class="changes-panel" color="surface" rounded="lg" elevation="1">
     <VListSubheader class="changes-header border-b" color="text-medium-emphasis">
       Changes
     </VListSubheader>
@@ -62,8 +62,6 @@ const formatDate = ({ createdAt }: Revision) => {
 
 <style lang="scss" scoped>
 .changes-panel {
-  --v-theme-overlay-multiplier: 0.8;
-
   display: flex;
   flex-direction: column;
   max-height: 32rem;

--- a/apps/frontend/app/components/repository/Revisions/EntitySidebar.vue
+++ b/apps/frontend/app/components/repository/Revisions/EntitySidebar.vue
@@ -1,36 +1,39 @@
 <template>
-  <VList class="rounded-lg pa-0" max-height="32rem">
-    <VListSubheader color="text-medium-emphasis">Changes</VListSubheader>
-    <VDivider />
-    <VHover
-      v-for="(revision, index) in revisions"
-      :key="revision.id"
-      v-slot="{ isHovering, props: hoverProps }"
-    >
-      <VListItem
-        v-bind="hoverProps"
-        :active="isSelected(revision)"
-        :subtitle="revision.user?.label"
-        :title="formatDate(revision)"
-        class="position-relative"
-        lines="two"
-        @click="$emit('preview', revision)"
+  <div class="changes-panel bg-surface-container-low rounded-lg">
+    <VListSubheader class="changes-header border-b" color="text-medium-emphasis">
+      Changes
+    </VListSubheader>
+    <VList class="changes-list" bg-color="transparent" nav>
+      <VHover
+        v-for="(revision, index) in revisions"
+        :key="revision.id"
+        v-slot="{ isHovering, props: hoverProps }"
       >
-        <template v-if="isHovering" #append>
-          <VBtn
-            v-show="!isDetached && index > 0 && !loading[revision.id]"
-            class="rollback"
-            icon="mdi-restore"
-            size="small"
-            variant="tonal"
-            @click="$emit('rollback', revision)"
-          />
-        </template>
-        <VProgressLinear v-if="loading[revision.id]" indeterminate />
-      </VListItem>
-      <VDivider v-if="index < revisions.length - 1" />
-    </VHover>
-  </VList>
+        <VListItem
+          v-bind="hoverProps"
+          :active="isSelected(revision)"
+          :subtitle="revision.user?.label"
+          :title="formatDate(revision)"
+          color="primary"
+          class="position-relative"
+          @click="$emit('preview', revision)"
+        >
+          <template v-if="isHovering" #append>
+            <VBtn
+              v-show="!isDetached && index > 0 && !loading[revision.id]"
+              class="rollback"
+              density="comfortable"
+              icon="mdi-restore"
+              size="small"
+              variant="tonal"
+              @click="$emit('rollback', revision)"
+            />
+          </template>
+          <VProgressLinear v-if="loading[revision.id]" indeterminate />
+        </VListItem>
+      </VHover>
+    </VList>
+  </div>
 </template>
 
 <script lang="ts" setup>
@@ -58,6 +61,27 @@ const formatDate = ({ createdAt }: Revision) => {
 </script>
 
 <style lang="scss" scoped>
+.changes-panel {
+  display: flex;
+  flex-direction: column;
+  max-height: 32rem;
+  overflow: hidden;
+}
+
+.changes-header {
+  flex: none;
+}
+
+.changes-list {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.changes-list :deep(.v-list-item) {
+  overflow: hidden;
+}
+
 .v-progress-linear {
   position: absolute;
   top: unset;

--- a/apps/frontend/app/components/repository/Revisions/RevisionItem.vue
+++ b/apps/frontend/app/components/repository/Revisions/RevisionItem.vue
@@ -1,14 +1,22 @@
 <template>
-  <li>
+  <li class="elevation-1 rounded-lg">
     <VListItem
       :active="isExpanded"
       :disabled="!isContentElement"
-      :rounded="isExpanded ? 'lg b-0' : 'lg'"
-      :subtitle="`${timeAgo} by ${revision.user.label}`"
-      :title="description"
-      class="revision"
+      :rounded="isExpanded ? 't-lg' : 'lg'"
+      class="revision bg-surface-raised"
       @click="toggle"
     >
+      <template #subtitle>
+        <span v-tooltip:bottom="{ text: fullTimestamp, openDelay: 300 }">
+          {{ timeOfDay }} · {{ revision.user.label }}
+        </span>
+      </template>
+      <template #title>
+        <VListItemTitle class="text-title-small font-weight-medium text-truncate">
+          {{ description }}
+        </VListItemTitle>
+      </template>
       <template #prepend>
         <VAvatar
           :color="color"
@@ -34,7 +42,7 @@
 <script lang="ts" setup>
 import type { Activity } from '@tailor-cms/interfaces/activity';
 import { find } from 'lodash-es';
-import { formatTimeAgo } from '@vueuse/core';
+import { formatDate } from '@vueuse/core';
 import type { Revision } from '@tailor-cms/interfaces/revision';
 
 import EntityRevisions from './EntityRevisions.vue';
@@ -67,7 +75,10 @@ const description = computed(() =>
   getFormatDescription(props.revision, activity.value),
 );
 
-const timeAgo = computed(() => formatTimeAgo(date.value, { rounding: 'floor' }));
+const timeOfDay = computed(() => formatDate(date.value, 'h:mm A'));
+const fullTimestamp = computed(() =>
+  formatDate(date.value, 'MMMM Do, YYYY h:mm A'),
+);
 
 const isContentElement = computed(
   () => props.revision.entity === 'CONTENT_ELEMENT',

--- a/apps/frontend/app/components/repository/Revisions/RevisionItem.vue
+++ b/apps/frontend/app/components/repository/Revisions/RevisionItem.vue
@@ -8,7 +8,7 @@
     >
       <template #subtitle>
         <span v-tooltip:bottom="{ text: fullTimestamp, openDelay: 300 }">
-          {{ timeOfDay }} · {{ revision.user.label }}
+          {{ timeOfDay }} · {{ revision.user?.label }}
         </span>
       </template>
       <template #title>

--- a/apps/frontend/app/components/repository/Revisions/RevisionItem.vue
+++ b/apps/frontend/app/components/repository/Revisions/RevisionItem.vue
@@ -1,7 +1,6 @@
 <template>
   <li class="elevation-1 rounded-lg">
     <VListItem
-      :active="isExpanded"
       :disabled="!isContentElement"
       :rounded="isExpanded ? 't-lg' : 'lg'"
       class="revision bg-surface-raised"

--- a/apps/frontend/app/components/repository/Search/ElementCard.vue
+++ b/apps/frontend/app/components/repository/Search/ElementCard.vue
@@ -60,13 +60,9 @@
         icon="mdi-open-in-new"
         @click.stop="openInNewTab"
       />
-      <VBtn
-        :aria-label="isExpanded ? 'Collapse preview' : 'Expand preview'"
+      <VIcon
         :icon="isExpanded ? 'mdi-chevron-up' : 'mdi-chevron-down'"
-        class="ml-1"
-        density="comfortable"
-        variant="text"
-        @click.stop="isExpanded = !isExpanded"
+        class="mx-2"
       />
     </VCard>
     <SearchSnippet
@@ -74,18 +70,20 @@
       :snippet="element.searchSnippet"
       class="mx-4 mt-3"
     />
-    <div v-if="showPreview" class="preview-region mx-4 mb-3">
-      <CardPreview :element="element" :search-terms="searchTerms" />
-      <VBtn
-        aria-label="Expand preview"
-        class="expand-btn"
-        density="comfortable"
-        icon="mdi-arrow-expand"
-        size="small"
-        variant="elevated"
-        @click.stop="emit('element:preview', element)"
-      />
-    </div>
+    <VExpandTransition>
+      <div v-if="showPreview" class="preview-region mx-4 mb-3">
+        <CardPreview :element="element" :search-terms="searchTerms" />
+        <VBtn
+          aria-label="Expand preview"
+          class="expand-btn"
+          density="comfortable"
+          icon="mdi-arrow-expand"
+          size="small"
+          variant="elevated"
+          @click.stop="emit('element:preview', element)"
+        />
+      </div>
+    </VExpandTransition>
   </VCard>
 </template>
 

--- a/apps/frontend/app/components/repository/Settings/UserManagement/UserGroupList.vue
+++ b/apps/frontend/app/components/repository/Settings/UserManagement/UserGroupList.vue
@@ -12,13 +12,14 @@
     :items-per-page="ITEMS_PER_PAGE"
   >
     <template #default="{ items }">
-      <VList class="group-list pa-0" bg-color="transparent">
+      <VList class="group-list pa-0 overflow-visible" bg-color="transparent">
         <VListItem
           v-for="{ raw: group } in items"
           :key="group.id"
           :to="{ name: 'user-group', params: { userGroupId: group.id } }"
           :title="group.name"
-          class="group-row bg-surface-container py-3 px-4 mb-2"
+          class="group-row bg-surface-raised py-3 px-4 mb-2"
+          elevation="1"
           rounded="lg"
         >
           <template #prepend>

--- a/apps/frontend/app/components/repository/Settings/UserManagement/UserList.vue
+++ b/apps/frontend/app/components/repository/Settings/UserManagement/UserList.vue
@@ -12,13 +12,14 @@
     :items-per-page="ITEMS_PER_PAGE"
   >
     <template #default="{ items }">
-      <VList class="user-list pa-0" bg-color="transparent">
+      <VList class="user-list pa-0 overflow-visible" bg-color="transparent">
         <VListItem
           v-for="{ raw: user } in (items as unknown as { raw: RepositoryUser }[])"
           :key="user.id"
           :subtitle="user.fullName ? user.email : ''"
           :title="user.label || user.email"
-          class="user-row bg-surface-container py-3 px-4 mb-2"
+          class="user-row bg-surface-raised py-3 px-4 mb-2"
+          elevation="1"
           rounded="lg"
         >
           <template #prepend>

--- a/apps/frontend/app/lib/revision.ts
+++ b/apps/frontend/app/lib/revision.ts
@@ -1,5 +1,8 @@
-import { get, isEmpty, reduce } from 'lodash-es';
+import { get, isEmpty, last, reduce } from 'lodash-es';
 import { lowerCase, titleCase } from '@tailor-cms/utils';
+import { formatDate } from '@vueuse/core';
+import { isToday } from 'date-fns/isToday';
+import { isYesterday } from 'date-fns/isYesterday';
 import type { Activity } from '@tailor-cms/interfaces/activity';
 import type { ContentElement } from '@tailor-cms/interfaces/content-element';
 import { Entity } from '@tailor-cms/interfaces/revision';
@@ -101,6 +104,36 @@ function describeElementRevision(
 
 function describeRepositoryRevision(rev: Revision) {
   return `${getAction(rev.operation)} repository`;
+}
+
+export interface DayGroup<T> {
+  key: string;
+  label: string;
+  items: T[];
+}
+
+function dayLabel(date: Date) {
+  if (isToday(date)) return 'Today';
+  if (isYesterday(date)) return 'Yesterday';
+  return formatDate(date, 'MMMM Do, YYYY');
+}
+
+/**
+ * Buckets a DESC-ordered list of dated entries into calendar-day groups. A
+ * single linear pass suffices because the input is already sorted newest-first.
+ */
+export function groupByDay<T extends { createdAt: string | Date }>(
+  items: T[],
+): DayGroup<T>[] {
+  const groups: DayGroup<T>[] = [];
+  for (const item of items) {
+    const date = new Date(item.createdAt);
+    const key = formatDate(date, 'YYYY-MM-DD');
+    const current = last(groups);
+    if (current?.key === key) current.items.push(item);
+    else groups.push({ key, label: dayLabel(date), items: [item] });
+  }
+  return groups;
 }
 
 export function isSameInstance(a: Revision, b: Revision) {

--- a/apps/frontend/app/pages/repository/[[id]]/root/revisions.vue
+++ b/apps/frontend/app/pages/repository/[[id]]/root/revisions.vue
@@ -159,7 +159,7 @@ onMounted(() => fetchRevisions());
 
   .revision-day-items {
     margin: 0;
-    padding: 0;
+    padding: 0.125rem 0 0.25rem;
   }
 }
 
@@ -168,7 +168,8 @@ onMounted(() => fetchRevisions());
   position: sticky;
   top: 0;
   z-index: 1;
-  padding: 0.75rem 0.5rem 0.5rem;
+  padding: 0.25rem 0.5rem 0.5rem;
+  margin-top: 0.75rem;
   margin-left: -0.125rem;
   width: calc(100% + 0.25rem);
 }

--- a/apps/frontend/app/pages/repository/[[id]]/root/revisions.vue
+++ b/apps/frontend/app/pages/repository/[[id]]/root/revisions.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="revisions-page overflow-auto h-100">
+  <div ref="scrollerEl" class="revisions-page overflow-auto h-100">
     <VContainer max-width="1200">
       <VInfiniteScroll
         v-if="bundledRevisions.length > 0"
@@ -8,11 +8,24 @@
         @load="loadMore"
       >
         <VList bg-color="transparent" lines="two" tag="ul">
-          <RevisionItem
-            v-for="revision in bundledRevisions"
-            :key="revision.uid"
-            :revision="revision"
-          />
+          <li
+            v-for="group in groupedRevisions"
+            :key="group.key"
+            class="revision-day-group"
+          >
+            <div class="revision-day-header">
+              <span class="text-label-medium text-uppercase text-medium-emphasis">
+                {{ group.label }}
+              </span>
+            </div>
+            <ul class="revision-day-items">
+              <RevisionItem
+                v-for="revision in group.items"
+                :key="revision.uid"
+                :revision="revision"
+              />
+            </ul>
+          </li>
         </VList>
         <template #load-more="{ props: scrollProps }">
           <VBtn
@@ -32,15 +45,28 @@
         prominent
       />
     </VContainer>
+    <VFadeTransition>
+      <VBtn
+        v-show="isScrolled"
+        aria-label="Back to top"
+        class="back-to-top"
+        color="primary"
+        icon="mdi-arrow-up"
+        size="small"
+        variant="tonal"
+        @click="scrollToTop"
+      />
+    </VFadeTransition>
   </div>
 </template>
 
 <script lang="ts" setup>
 import { last, reduce, uniq, uniqBy } from 'lodash-es';
+import { useScroll } from '@vueuse/core';
 import type { Revision } from '@tailor-cms/interfaces/revision';
 
 import { api } from '@/api';
-import { isSameRun } from '@/lib/revision';
+import { groupByDay, isSameRun } from '@/lib/revision';
 import RevisionItem from '@/components/repository/Revisions/RevisionItem.vue';
 import { useActivityStore } from '@/stores/activity';
 import { useCurrentRepository } from '@/stores/current-repository';
@@ -79,6 +105,8 @@ const bundledRevisions = computed<Revision[]>(() => {
   );
 });
 
+const groupedRevisions = computed(() => groupByDay(bundledRevisions.value));
+
 const fetchRevisions = async () => {
   isFetching.value = true;
   const repositoryId = currentRepositoryStore.repository?.id;
@@ -104,21 +132,45 @@ const loadMore = async (options: any) => {
   options.done('ok');
 };
 
+const scrollerEl = ref<HTMLElement | null>(null);
+const { y } = useScroll(scrollerEl);
+const isScrolled = computed(() => y.value > 400);
+const scrollToTop = () =>
+  scrollerEl.value?.scrollTo({ top: 0, behavior: 'smooth' });
+
 onMounted(() => fetchRevisions());
 </script>
 
 <style lang="scss" scoped>
 .revisions {
   text-align: left;
+  // VInfiniteScroll and VList default to overflow:auto, which would trap the
+  // sticky headers; clear it so they resolve to the .revisions-page scroller.
+  overflow: visible;
 
   ul {
-    padding: 0.5rem 0;
+    overflow: visible;
     list-style-type: none;
 
     li {
       width: 100%;
     }
   }
+
+  .revision-day-items {
+    margin: 0;
+    padding: 0;
+  }
+}
+
+.revision-day-header {
+  background: rgb(var(--v-theme-surface-container-low));
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  padding: 0.75rem 0.5rem 0.5rem;
+  margin-left: -0.125rem;
+  width: calc(100% + 0.25rem);
 }
 
 .revisions-page {
@@ -128,5 +180,12 @@ onMounted(() => fetchRevisions());
   &::-webkit-scrollbar {
     display: none;
   }
+}
+
+.back-to-top {
+  position: fixed;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  z-index: 5;
 }
 </style>


### PR DESCRIPTION
## Summary

UI polish for the editor sidebar tabs and the repository revisions / history views:

- **Sidebar tabs:** tooltips now appear only for collapsed icon-only tabs (no longer duplicated when the label is already visible), and the active tab animates its label in/out (icon ⇄ icon + label) when the sidebar is narrow.
- **Revisions page:** flat list rows with a cleaner sticky day-header and a back-to-top button for long histories.
- **Revision preview:** the "Changes" panel is now fixed-height with a static header above an independently scrolling list, so it stays steady as you switch revisions; on small screens it stacks above the preview.
- **Shared:** extracted day grouping into `groupByDay` (`lib/revision.ts`), reused by both the history sidebar and the revisions page.

## How to test

- Editor: narrow the left sidebar until tabs collapse to icons — hover an inactive tab (tooltip), switch tabs (label animates), confirm no tooltip on the active/labelled tab.
- Repository → **Revisions**: scroll a long history (sticky day headers, back-to-top), expand a content-element revision, and switch entries in **Changes** (steady height, pinned header, list scrolls). Narrow the window to confirm the sidebar stacks above the preview.

## Notes

- UI-only — no API / schema / migration changes.
- Add before/after screenshots of the sidebar tabs and the revisions header.