### PR TITLE
Fix issue with uploading a profile photo 

### DIFF
--- a/apps/backend/openapi.json
+++ b/apps/backend/openapi.json
@@ -12721,9 +12721,9 @@
                     "maxLength": 50
                   },
                   "imgUrl": {
-                    "description": "Avatar URL or base64 data URL (capped at 200_000 chars).",
+                    "description": "Avatar URL or base64 data URL (capped at 1_000_000 chars).",
                     "type": "string",
-                    "maxLength": 200000
+                    "maxLength": 1000000
                   }
                 },
                 "additionalProperties": false,

--- a/apps/backend/user/schemas/profile.ts
+++ b/apps/backend/user/schemas/profile.ts
@@ -24,10 +24,8 @@ export const ProfileUpdateInput = z
     email: User.shape.email.optional(),
     firstName: User.shape.firstName.unwrap().optional(),
     lastName: User.shape.lastName.unwrap().optional(),
-    // Generous ceiling
-    // covers any reasonable upload while gating obvious DoS payloads.
-    imgUrl: z.string().max(200_000).optional()
-      .describe('Avatar URL or base64 data URL (capped at 200_000 chars).'),
+    imgUrl: z.string().max(1_000_000).optional()
+      .describe('Avatar URL or base64 data URL (capped at 1_000_000 chars).'),
   })
   .describe(`Editable subset of the current user's profile.`);
 

--- a/apps/frontend/app/components/common/Avatar/index.vue
+++ b/apps/frontend/app/components/common/Avatar/index.vue
@@ -54,8 +54,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, ref } from 'vue';
-import Compressor from 'compressorjs';
+import { resizeAvatarImage } from './resize-image';
 
 export interface Props {
   imgUrl?: string;
@@ -77,28 +76,35 @@ const isGravatar = computed(() => /gravatar.com/.test(props.imgUrl));
 
 const triggerUpload = () => fileInput.value?.click();
 
-const selectPhoto = (event: Event) => {
-  const { files } = event.target as HTMLInputElement;
-  if (!files?.[0]) return;
-  return new Compressor(files[0], {
-    width: 250,
-    height: 250,
-    resize: 'cover',
-    success: async (result) => {
-      const imageUrl = await toBase64(result);
-      emit('save', imageUrl);
-    },
-    error: (err) => notify(err.message, { immediate: true, color: 'error' }),
-  });
-};
+const AVATAR_SIZE = 250;
+// A resized/compressed AVATAR_SIZE x AVATAR_SIZE JPEG data URL should land under
+const MAX_IMAGE_LENGTH = 300_000;
 
-const toBase64 = (file: Blob): Promise<string> => {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.readAsDataURL(file);
-    reader.onload = () => resolve(reader.result as string);
-    reader.onerror = (error) => reject(error);
-  });
+const selectPhoto = async (event: Event) => {
+  const input = event.target as HTMLInputElement;
+  const file = input.files?.[0];
+  input.value = '';
+  if (!file) return;
+  if (!file.type.startsWith('image/')) {
+    notify('Please select an image file.', {
+      immediate: true,
+      color: 'error',
+    });
+    return;
+  }
+  try {
+    const imageUrl = await resizeAvatarImage(file, AVATAR_SIZE);
+    if (imageUrl.length > MAX_IMAGE_LENGTH) {
+      notify('Unable to compress that image enough, please try a different one.', {
+        immediate: true,
+        color: 'error',
+      });
+      return;
+    }
+    emit('save', imageUrl);
+  } catch (err: any) {
+    notify(err.message, { immediate: true, color: 'error' });
+  }
 };
 </script>
 

--- a/apps/frontend/app/components/common/Avatar/resize-image.ts
+++ b/apps/frontend/app/components/common/Avatar/resize-image.ts
@@ -1,0 +1,83 @@
+import Compressor from 'compressorjs';
+
+const toBase64 = (blob: Blob): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.readAsDataURL(blob);
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = (error) => reject(error);
+  });
+};
+
+const compressWithLibrary = (file: File, size: number): Promise<Blob> => {
+  return new Promise((resolve, reject) => {
+    new Compressor(file, {
+      width: size,
+      height: size,
+      resize: 'cover',
+      mimeType: 'image/jpeg',
+      success: (result) => resolve(result),
+      error: reject,
+    });
+  });
+};
+
+/**
+ * Draws the image directly onto a canvas instead of going through a
+ * library's own canvas-support check. Some privacy-hardened browsers
+ * (e.g. Firefox's `privacy.resistFingerprinting`) randomize canvas pixel
+ * read-back specifically to defeat such checks, which makes compressorjs
+ * report canvas as unavailable and silently hand back the untouched
+ * original file instead of a resized one.
+ */
+const drawToCanvas = async (file: File, size: number): Promise<Blob> => {
+  const objectUrl = URL.createObjectURL(file);
+  try {
+    const image = new Image();
+    image.src = objectUrl;
+    try {
+      await image.decode();
+    } catch {
+      throw new Error('Failed to load the selected image.');
+    }
+    const canvas = new OffscreenCanvas(size, size);
+    const context = canvas.getContext('2d');
+    if (!context) {
+      throw new Error('Image resizing is not supported in this browser.');
+    }
+    const scale = Math.max(size / image.width, size / image.height);
+    const drawWidth = image.width * scale;
+    const drawHeight = image.height * scale;
+    context.drawImage(
+      image,
+      (size - drawWidth) / 2,
+      (size - drawHeight) / 2,
+      drawWidth,
+      drawHeight,
+    );
+    return await canvas.convertToBlob({ type: 'image/jpeg', quality: 0.8 });
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+  }
+};
+
+/**
+ * Resizes/crops an image file to a square JPEG data URL. Tries
+ * compressorjs first, since it also corrects EXIF orientation, but falls
+ * back to a direct canvas draw whenever compressorjs bails out and hands
+ * back the untouched original (its `result` is then the same object
+ * reference as `file`).
+ */
+export async function resizeAvatarImage(
+  file: File,
+  size: number,
+): Promise<string> {
+  let blob: Blob;
+  try {
+    blob = await compressWithLibrary(file, size);
+    if (blob === file) blob = await drawToCanvas(file, size);
+  } catch {
+    blob = await drawToCanvas(file, size);
+  }
+  return toBase64(blob);
+}

--- a/apps/frontend/app/pages/user/profile.vue
+++ b/apps/frontend/app/pages/user/profile.vue
@@ -39,9 +39,18 @@ const store = useAuthStore();
 const notify = useNotification();
 
 const saveAvatar = (imgUrl?: string) => {
-  return store.updateInfo({ imgUrl }).then(() => {
-    notify('Your profile picture has been updated!', { immediate: true });
-  });
+  return store
+    .updateInfo({ imgUrl })
+    .then(() => {
+      notify('Your profile picture has been updated!', { immediate: true });
+    })
+    .catch((err) => {
+      const message = err?.response?.data?.error?.message;
+      notify(message || 'Failed to update your profile picture!', {
+        immediate: true,
+        color: 'error',
+      });
+    });
 };
 
 const deleteAvatar = () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -571,7 +571,7 @@ importers:
         version: 10.5.0(postcss@8.5.15)
       nuxt:
         specifier: 4.4.6
-        version: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.3)(meow@14.1.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.34(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.4))(rollup@4.60.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(xml2js@0.6.2)(yaml@2.9.0)
+        version: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.3)(meow@14.1.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.34(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.4))(rollup@4.60.4)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.4)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(xml2js@0.6.2)(yaml@2.9.0)
       sass:
         specifier: ^1.100.0
         version: 1.100.0
@@ -1327,7 +1327,7 @@ importers:
     dependencies:
       nuxt:
         specifier: ^4.4.6
-        version: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.3)(meow@14.1.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.34(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.4))(rollup@4.60.4)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.4)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(xml2js@0.6.2)(yaml@2.9.0)
+        version: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.3)(meow@14.1.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.34(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.4))(rollup@4.60.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(xml2js@0.6.2)(yaml@2.9.0)
       pinia:
         specifier: ^3.0.4
         version: 3.0.4(typescript@6.0.3)(vue@3.5.34(typescript@6.0.3))
@@ -12998,7 +12998,7 @@ snapshots:
       https-proxy-agent: 7.0.6
       node-fetch: 2.7.0
       nopt: 8.1.0
-      semver: 7.8.1
+      semver: 7.8.5
       tar: 7.5.15
     transitivePeerDependencies:
       - encoding
@@ -13158,7 +13158,7 @@ snapshots:
 
   '@npmcli/fs@5.0.0':
     dependencies:
-      semver: 7.8.1
+      semver: 7.8.5
 
   '@npmcli/git@7.0.2':
     dependencies:
@@ -13168,7 +13168,7 @@ snapshots:
       lru-cache: 11.5.0
       npm-pick-manifest: 11.0.3
       proc-log: 6.1.0
-      semver: 7.8.1
+      semver: 7.8.5
       which: 6.0.1
 
   '@npmcli/installed-package-contents@4.0.0':
@@ -13189,7 +13189,7 @@ snapshots:
       json-parse-even-better-errors: 5.0.0
       pacote: 21.5.0
       proc-log: 6.1.0
-      semver: 7.8.1
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
 
@@ -13204,7 +13204,7 @@ snapshots:
       hosted-git-info: 9.0.3
       json-parse-even-better-errors: 5.0.0
       proc-log: 6.1.0
-      semver: 7.8.1
+      semver: 7.8.5
       spdx-expression-parse: 4.0.0
 
   '@npmcli/promise-spawn@9.0.1':
@@ -19612,7 +19612,7 @@ snapshots:
       graceful-fs: 4.2.11
       nopt: 9.0.0
       proc-log: 6.1.0
-      semver: 7.8.1
+      semver: 7.8.5
       tar: 7.5.15
       tinyglobby: 0.2.16
       undici: 6.25.0
@@ -19654,7 +19654,7 @@ snapshots:
 
   npm-install-checks@8.0.0:
     dependencies:
-      semver: 7.8.1
+      semver: 7.8.5
 
   npm-normalize-package-bin@5.0.0: {}
 
@@ -19662,7 +19662,7 @@ snapshots:
     dependencies:
       hosted-git-info: 9.0.3
       proc-log: 6.1.0
-      semver: 7.8.1
+      semver: 7.8.5
       validate-npm-package-name: 7.0.2
 
   npm-packlist@10.0.4:
@@ -19675,7 +19675,7 @@ snapshots:
       npm-install-checks: 8.0.0
       npm-normalize-package-bin: 5.0.0
       npm-package-arg: 13.0.2
-      semver: 7.8.1
+      semver: 7.8.5
 
   npm-registry-fetch@19.1.1:
     dependencies:


### PR DESCRIPTION
Uploading a profile photo was silently failing (400) for some users. Root cause: compressorjs's canvas-support probe gets fooled by privacy-hardening (e.g. Firefox resistFingerprinting), so it silently returns the original, unresized file — which then blew past the backend's avatar size cap.