### PR TITLE
Add notifications (toast) for repository actions

### DIFF
--- a/apps/frontend/app/app.vue
+++ b/apps/frontend/app/app.vue
@@ -1,8 +1,13 @@
 <template>
   <VApp>
     <NuxtPage />
+    <NotificationSnackbar />
   </VApp>
 </template>
+
+<script lang="ts" setup>
+import NotificationSnackbar from '@/components/common/NotificationSnackbar.vue';
+</script>
 
 <style lang="scss">
 .v-input.required {

--- a/apps/frontend/app/components/catalog/AddRepository/index.vue
+++ b/apps/frontend/app/components/catalog/AddRepository/index.vue
@@ -257,7 +257,7 @@ const createRepository = handleSubmit(async (formPayload: any) => {
   const action = isCreate.value ? create : importRepository;
   try {
     await pMinDelay(action(formPayload), 2000);
-    const repositoryTypeLabel = (schema.value?.name ?? 'item').toLowerCase();
+    const repositoryTypeLabel = schema.value?.name ?? 'Item';
     notify(
       isCreate.value
         ? `A new ${repositoryTypeLabel} has been created`

--- a/apps/frontend/app/components/catalog/AddRepository/index.vue
+++ b/apps/frontend/app/components/catalog/AddRepository/index.vue
@@ -161,17 +161,18 @@
 </template>
 
 <script lang="ts" setup>
-import type { ActivityConfig } from '@tailor-cms/interfaces/schema';
-import { formDataBodySerializer } from '@tailor-cms/api-client';
 import { pick, startCase } from 'lodash-es';
-import pMinDelay from 'p-min-delay';
-import { SCHEMAS } from '@tailor-cms/config';
+import { formDataBodySerializer } from '@tailor-cms/api-client';
+import { schema as schemaApi } from '@tailor-cms/config';
 import { TailorDialog } from '@tailor-cms/core-components';
 import { useForm } from 'vee-validate';
+import pMinDelay from 'p-min-delay';
 
 import { api } from '@/api';
 import MetaInput from '@/components/common/MetaInput.vue';
 import RepositoryNameField from '@/components/common/RepositoryNameField.vue';
+
+const notify = useNotification();
 
 const authStore = useAuthStore();
 const repositoryStore = useRepositoryStore();
@@ -232,8 +233,8 @@ const [descriptionInput] = defineField('description');
 const [archiveInput] = defineField('archive');
 const [groupInput] = defineField('userGroupIds');
 
-const schema = computed<ActivityConfig>(
-  () => SCHEMAS.find((it) => it.id === schemaInput.value) as any,
+const schema = computed(() =>
+  schemaInput.value ? schemaApi.getSchema(schemaInput.value) : undefined,
 );
 
 const schemaMeta = computed(() =>
@@ -256,6 +257,13 @@ const createRepository = handleSubmit(async (formPayload: any) => {
   const action = isCreate.value ? create : importRepository;
   try {
     await pMinDelay(action(formPayload), 2000);
+    const repositoryTypeLabel = (schema.value?.name ?? 'item').toLowerCase();
+    notify(
+      isCreate.value
+        ? `A new ${repositoryTypeLabel} has been created`
+        : 'Import successful',
+      { immediate: true },
+    );
     emit('created');
     hide();
   } catch {

--- a/apps/frontend/app/components/catalog/AddRepository/index.vue
+++ b/apps/frontend/app/components/catalog/AddRepository/index.vue
@@ -151,8 +151,8 @@
       />
       <VBtn
         :loading="isSubmitting"
+        :text="isCreate ? 'Create' : 'Import'"
         color="primary"
-        text="Create"
         type="submit"
         variant="flat"
       />
@@ -257,10 +257,9 @@ const createRepository = handleSubmit(async (formPayload: any) => {
   const action = isCreate.value ? create : importRepository;
   try {
     await pMinDelay(action(formPayload), 2000);
-    const repositoryTypeLabel = schema.value?.name ?? 'Item';
     notify(
       isCreate.value
-        ? `A new ${repositoryTypeLabel} has been created`
+        ? `A new ${schema.value!.name} has been created`
         : 'Import successful',
       { immediate: true },
     );

--- a/apps/frontend/app/components/catalog/Card/index.vue
+++ b/apps/frontend/app/components/catalog/Card/index.vue
@@ -160,9 +160,7 @@ const onAction = (name: CardAction['name']) => {
 const schema = ref(null);
 
 const isSchemaNameTruncated = ref(false);
-const schemaName = computed(
-  () => $schemaService.getSchema(props.repository.schema).name,
-);
+const schemaName = computed(() => $schemaService.getLabel(props.repository));
 
 const lastActivity = computed(
   () => first(props.repository.revisions) as Revision,

--- a/apps/frontend/app/components/catalog/Filter/UserGroupSelect.vue
+++ b/apps/frontend/app/components/catalog/Filter/UserGroupSelect.vue
@@ -36,7 +36,7 @@ import UserGroupAvatar from '@/components/common/UserGroupAvatar.vue';
 interface UserGroupOption {
   id: number;
   name: string;
-  logoUrl?: string;
+  logoUrl?: string | null;
 }
 
 defineProps<{ items: UserGroupOption[] }>();

--- a/apps/frontend/app/components/common/ActivityOptions/ActivityMenu.vue
+++ b/apps/frontend/app/components/common/ActivityOptions/ActivityMenu.vue
@@ -58,10 +58,13 @@
 </template>
 
 <script lang="ts" setup>
-import { first, sortBy } from 'lodash-es';
 import type { ActivityConfig } from '@tailor-cms/interfaces/schema';
-import { InsertLocation } from '@tailor-cms/utils';
 import type { StoreActivity } from '@/stores/activity';
+
+import { sortBy } from 'lodash-es';
+import { InsertLocation } from '@tailor-cms/utils';
+import { schema as schemaApi } from '@tailor-cms/config';
+import pluralize from 'pluralize-esm';
 
 import CopyDialog from '@/components/repository/Outline/CopyActivity/index.vue';
 import CreateDialog from '@/components/repository/Outline/CreateDialog/index.vue';
@@ -72,6 +75,10 @@ import { useSelectedActivity } from '#imports';
 const { AddAfter, AddBefore, AddInto } = InsertLocation;
 const activityStore = useActivityStore();
 const currentRepositoryStore = useCurrentRepository();
+const { requestDeletion } = useCollectionItemDeletion();
+
+const confirmationDialog = useConfirmationDialog();
+const notify = useNotification();
 
 export interface Props {
   activity: StoreActivity;
@@ -85,7 +92,7 @@ const props = withDefaults(defineProps<Props>(), {
   rounded: 'circle',
 });
 
-const { $eventBus, $pluginRegistry } = useNuxtApp() as any;
+const { $pluginRegistry } = useNuxtApp() as any;
 const selectedActivity = useSelectedActivity(props.activity);
 
 const isOpen = defineModel<boolean>({ default: false });
@@ -187,20 +194,40 @@ const setLinkContext = (actionValue: InsertLocation) => {
   showLinkDialog.value = true;
 };
 
+const focusNearestActivity = () => {
+  const { activity } = props;
+  const roots = sortBy(currentRepositoryStore.rootActivities, 'position');
+  const focusNode = activity.parentId
+    ? activityStore.findById(activity.parentId)
+    : roots.find((it) => it.id !== activity.id);
+  if (focusNode) return currentRepositoryStore.selectActivity(focusNode.id);
+  currentRepositoryStore.deselectActivity();
+};
+
 const deleteActivity = () => {
   const { activity } = props;
-  const actionFunc = () => {
-    const focusNode = activity.parentId
-      ? activityStore.findById(activity.parentId)
-      : first(sortBy(currentRepositoryStore.rootActivities, 'position'));
-    activityStore.remove(props.activity.id);
-    if (focusNode) currentRepositoryStore.selectActivity(focusNode.id);
-  };
-  $eventBus.channel('app').emit('showConfirmationModal', {
-    title: 'Delete item?',
+  // Collection records go through the reference-aware deletion flow
+  if (currentRepositoryStore.isCollection) {
+    return requestDeletion(activity, focusNearestActivity);
+  }
+  // Singularized - shared with grammar of other type-aware messages
+  const label = pluralize.singular(
+    schemaApi.getActivityLabel(activity) || 'item',
+  );
+  confirmationDialog({
+    title: `Delete ${label}?`,
     color: 'error',
-    message: `Are you sure you want to delete ${activityName.value}?`,
-    action: actionFunc,
+    message:
+      `Are you sure you want to delete the ${label} "${activityName.value}"?`,
+    action: async () => {
+      try {
+        await activityStore.remove(activity.id);
+        notify(`The ${label} has been deleted`, { immediate: true });
+        focusNearestActivity();
+      } catch {
+        notify(`We couldn't delete the ${label}`, { color: 'error' });
+      }
+    },
   });
 };
 </script>

--- a/apps/frontend/app/components/common/ConfirmationDialog.vue
+++ b/apps/frontend/app/components/common/ConfirmationDialog.vue
@@ -2,8 +2,8 @@
   <TailorDialog
     v-model="isVisible"
     :color="context.color"
+    :header-icon="context.icon"
     :title="context.title"
-    header-icon="mdi-alert"
     @click:outside="close"
   >
     <template #body>
@@ -35,6 +35,7 @@ const createContext = () => ({
   title: '',
   message: '',
   color: 'primary',
+  icon: 'mdi-alert',
   action: () => {},
 });
 

--- a/apps/frontend/app/components/common/NotificationSnackbar.vue
+++ b/apps/frontend/app/components/common/NotificationSnackbar.vue
@@ -57,11 +57,6 @@ const schedule = (opts: NotificationOptions) => {
   return (opts.immediate ? addToQueue : debounce(addToQueue, 2500))(opts);
 };
 
-watch(isVisible, (visible) => {
-  if (visible) return;
-  context.value = initialData();
-});
-
 onMounted(() => {
   const appChannel = $eventBus.channel('app');
   appChannel.on('showNotificationSnackbar', (opts: NotificationOptions) => {

--- a/apps/frontend/app/components/editor/Toolbar/index.vue
+++ b/apps/frontend/app/components/editor/Toolbar/index.vue
@@ -40,6 +40,7 @@
             v-if="activity.publishedAt"
             :text="formatDate(activity.publishedAt, 'MM/dd/yy HH:mm')"
             class="ml-2"
+            data-percy="hide"
             size="x-small"
             label
           />

--- a/apps/frontend/app/components/repository/Library/LinkContent.vue
+++ b/apps/frontend/app/components/repository/Library/LinkContent.vue
@@ -7,15 +7,18 @@
     persistent
   >
     <template #body>
+      <p class="text-body-medium text-medium-emphasis mb-5">
+        The selected content will be linked {{ destination }}.
+      </p>
       <VAutocomplete
         :items="repositories"
         :loading="isLoadingRepositories"
         :menu-props="{ maxWidth: '100%' }"
+        :label="sourceLabel"
         :model-value="selectedRepository"
+        :placeholder="sourcePlaceholder"
         item-title="name"
         item-value="id"
-        label="Select a Repository"
-        placeholder="Type to search repositories..."
         prepend-inner-icon="mdi-magnify"
         variant="outlined"
         return-object
@@ -36,7 +39,6 @@
     <template #actions>
       <VBtn
         :disabled="isLinking"
-
         text="Cancel"
         variant="text"
         @click="close"
@@ -55,15 +57,17 @@
 </template>
 
 <script lang="ts" setup>
-import { TailorDialog, useLoader } from '@tailor-cms/core-components';
 import type { Activity } from '@tailor-cms/interfaces/activity';
-import { InsertLocation } from '@tailor-cms/utils';
-import pluralize from 'pluralize-esm';
 import type { Repository } from '@tailor-cms/interfaces/repository';
-import { sortBy } from 'lodash-es';
+
+import { TailorDialog, useLoader } from '@tailor-cms/core-components';
+import { InsertLocation } from '@tailor-cms/utils';
+import { sortBy, upperFirst } from 'lodash-es';
 import { storeToRefs } from 'pinia';
+import pluralize from 'pluralize-esm';
 
 import { api } from '@/api';
+import { describeSelection } from '@/utils/describeSelection';
 import { useActivityStore } from '@/stores/activity';
 import { useCurrentRepository } from '@/stores/current-repository';
 import RepositoryTree from '../Outline/CopyActivity/RepositoryTree.vue';
@@ -82,8 +86,10 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 const { $schemaService } = useNuxtApp() as any;
+
 const currentRepositoryStore = useCurrentRepository();
 const activityStore = useActivityStore();
+const notify = useNotification();
 
 const { loading: isLoadingRepositories, loader } = useLoader();
 const { repository } = storeToRefs(currentRepositoryStore);
@@ -98,7 +104,35 @@ const isLinking = ref(false);
 
 const schemaName = computed(() => {
   if (!selectedRepository.value) return '';
-  return $schemaService.getSchema(selectedRepository.value.schema).name;
+  return $schemaService.getLabel(selectedRepository.value);
+});
+
+// Where the selection lands, e.g. `below "History of Pizza"`
+const destination = computed(() => {
+  const anchorName = props.anchor?.data?.name;
+  if (!anchorName) return `into this ${currentRepositoryStore.schemaName}`;
+  return `${props.action === AddInto ? 'into' : 'below'} "${anchorName}"`;
+});
+
+// Content can be linked from same-type repositories and from types that map
+// to it (mapsTo), so name them all, with the current type first.
+const sourceTypeNames = computed(() => {
+  const schemaId = repository.value!.schema;
+  const ids = $schemaService.getCompatibleSchemaIds(schemaId);
+  const ordered = [schemaId, ...ids.filter((id: string) => id !== schemaId)];
+  return ordered.map((id) => $schemaService.getSchema(id).name as string);
+});
+
+const sourceLabel = computed(() => {
+  const names = sourceTypeNames.value;
+  if (names.length > 2) return 'Select a source';
+  return `Select a ${names.join(' or ')}`;
+});
+
+const sourcePlaceholder = computed(() => {
+  const names = sourceTypeNames.value;
+  if (names.length > 2) return 'Type to search...';
+  return `Type to search ${names.map((it) => pluralize(it)).join(' or ')}...`;
 });
 
 // Get all outline activity types from the selected repository's schema
@@ -109,11 +143,14 @@ const supportedLevels = computed(() => {
   return outlineLevels.map((level: any) => level.type);
 });
 
+const selectionSummary = computed(() =>
+  describeSelection(selectedActivities.value.map((it) => activityLabel(it))),
+);
+
 const linkBtnLabel = computed(() => {
-  const count = selectedActivities.value.length;
+  const { count, countLabel } = selectionSummary.value;
   if (!count) return 'Link';
-  const label = pluralize('item', count, true);
-  return `Link ${label} ${props.action === AddInto ? 'inside' : ''}`;
+  return `Link ${countLabel}${props.action === AddInto ? ' inside' : ''}`;
 });
 
 const fetchRepositories = loader(async (search = '') => {
@@ -162,11 +199,17 @@ const linkActivity = async (
   return linked;
 };
 
+const activityLabel = (item?: Activity) => {
+  const source = repositoryActivities.value.find((it) => it.id === item?.id);
+  return (source && $schemaService.getActivityLabel(source)) || 'Item';
+};
+
 const linkSelection = async () => {
   if (!selectedActivities.value.length) return;
   isLinking.value = true;
+  const items = sortBy(selectedActivities.value, ['parentId', 'position']);
+  const { noun, verb } = selectionSummary.value;
   try {
-    const items = sortBy(selectedActivities.value, ['parentId', 'position']);
     let prevLinkedItem: Activity | undefined;
     let firstLinked: Activity | undefined;
     for (const item of items) {
@@ -174,9 +217,12 @@ const linkSelection = async () => {
       if (!firstLinked) firstLinked = linked[0];
       prevLinkedItem = linked[0];
     }
+    notify(`${upperFirst(noun)} ${verb} been linked`, { immediate: true });
     emit('completed', items);
     if (firstLinked) currentRepositoryStore.selectActivity(firstLinked.id);
     close();
+  } catch {
+    notify(`We couldn't link ${noun}`, { color: 'error' });
   } finally {
     isLinking.value = false;
   }

--- a/apps/frontend/app/components/repository/Library/LinkedIndicator/index.vue
+++ b/apps/frontend/app/components/repository/Library/LinkedIndicator/index.vue
@@ -56,9 +56,7 @@ const source = ref<SourceInfo | null>(null);
 const sourceLabel = computed(() => {
   const repo = source.value?.repository;
   if (!repo?.name) return '';
-  const schemaName = repo.schema
-    ? $schemaService.getSchema(repo.schema).name
-    : '';
+  const schemaName = repo.schema ? $schemaService.getLabel(repo) : '';
   const label = schemaName ? `${repo.name} ${schemaName}` : repo.name;
   return `from ${label}`;
 });

--- a/apps/frontend/app/components/repository/Outline/CollectionItem.vue
+++ b/apps/frontend/app/components/repository/Outline/CollectionItem.vue
@@ -61,7 +61,7 @@
 import { activity as activityUtils } from '@tailor-cms/utils';
 import { formatDate } from 'date-fns/format';
 import { formatDistanceToNow } from 'date-fns/formatDistanceToNow';
-import { first, sortBy } from 'lodash-es';
+import { sortBy } from 'lodash-es';
 import { storeToRefs } from 'pinia';
 
 import type { StoreActivity } from '@/stores/activity';
@@ -109,8 +109,10 @@ const openActivity = () => {
 
 const deleteActivity = () =>
   requestDeletion(props.activity, () => {
-    const focusNode = first(sortBy(repositoryStore.rootActivities, 'position'));
-    if (focusNode) repositoryStore.selectActivity(focusNode.id);
+    const roots = sortBy(repositoryStore.rootActivities, 'position');
+    const focusNode = roots.find((it) => it.id !== props.activity.id);
+    if (focusNode) return repositoryStore.selectActivity(focusNode.id);
+    repositoryStore.deselectActivity();
   });
 
 onMounted(() => {

--- a/apps/frontend/app/components/repository/Outline/CopyActivity/index.vue
+++ b/apps/frontend/app/components/repository/Outline/CopyActivity/index.vue
@@ -18,7 +18,7 @@
       </p>
       <VAutocomplete
         :items="repositories"
-        :label="store.schemaName"
+        :label="`Select a ${store.schemaName}`"
         :loading="isFetchingRepositories"
         :menu-props="{ maxWidth: '100%' }"
         :model-value="selectedRepository"

--- a/apps/frontend/app/components/repository/Outline/CopyActivity/index.vue
+++ b/apps/frontend/app/components/repository/Outline/CopyActivity/index.vue
@@ -1,27 +1,30 @@
 <template>
   <TailorDialog
     v-model="visible"
-    :title="schema ? `Copy items from ${pluralize(schema.name)}` : 'Copy items'"
     header-icon="mdi-content-copy"
+    title="Copy existing content"
     width="650"
     persistent
   >
-    <template v-if="schema" #body>
+    <template #body>
       <div v-if="isCopyingActivities" class="ma-4">
         <div class="text-body-large text-center mb-2">
-          Copying {{ selectedActivities.length }} items...
+          Copying {{ selectionSummary.countLabel }}...
         </div>
         <VProgressLinear color="primary" indeterminate />
       </div>
+      <p class="text-body-medium text-medium-emphasis mb-5">
+        The selected content will be copied {{ destination }}.
+      </p>
       <VAutocomplete
         :items="repositories"
-        :label="schema.name"
+        :label="store.schemaName"
         :loading="isFetchingRepositories"
         :menu-props="{ maxWidth: '100%' }"
         :model-value="selectedRepository"
+        :placeholder="`Type to search ${pluralize(store.schemaName)}...`"
         item-title="name"
         item-value="id"
-        placeholder="Type to search repositories..."
         prepend-inner-icon="mdi-magnify"
         variant="outlined"
         return-object
@@ -31,7 +34,7 @@
       <RepositoryTree
         v-if="selectedRepository && !isFetchingActivities"
         :activities="selectedRepository.activities || []"
-        :schema-name="schema.name"
+        :schema-name="store.schemaName"
         :supported-levels="levels"
         @change="selectedActivities = $event"
       />
@@ -55,16 +58,17 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, ref } from 'vue';
-import { TailorDialog, useLoader } from '@tailor-cms/core-components';
 import type { Activity } from '@tailor-cms/interfaces/activity';
-import { InsertLocation } from '@tailor-cms/utils';
-import pluralize from 'pluralize-esm';
 import type { Repository } from '@tailor-cms/interfaces/repository';
-import { SCHEMAS } from '@tailor-cms/config';
-import { sortBy } from 'lodash-es';
+
+import { sortBy, upperFirst } from 'lodash-es';
+import { TailorDialog, useLoader } from '@tailor-cms/core-components';
+import { InsertLocation } from '@tailor-cms/utils';
+import { schema as schemaApi } from '@tailor-cms/config';
+import pluralize from 'pluralize-esm';
 
 import { api } from '@/api';
+import { describeSelection } from '@/utils/describeSelection';
 import { useActivityStore } from '@/stores/activity';
 import { useCurrentRepository } from '@/stores/current-repository';
 import RepositoryTree from './RepositoryTree.vue';
@@ -81,7 +85,10 @@ interface Props {
 const props = withDefaults(defineProps<Props>(), {
   anchor: null,
 });
+
 const emit = defineEmits(['close', 'completed']);
+
+const notify = useNotification();
 
 const store = useCurrentRepository();
 const activityStore = useActivityStore();
@@ -94,16 +101,21 @@ const selectedActivities = ref<Activity[]>([]);
 const isFetchingActivities = ref(false);
 const isCopyingActivities = ref(false);
 
-const schema = computed(() =>
-  SCHEMAS.find((it) => store.repository?.schema === it.id),
+// Where the selection lands, e.g. `below "History of Pizza"`
+const destination = computed(() => {
+  const anchorName = props.anchor?.data?.name;
+  if (!anchorName) return `into this ${store.schemaName}`;
+  return `${props.action === AddInto ? 'into' : 'below'} "${anchorName}"`;
+});
+
+const selectionSummary = computed(() =>
+  describeSelection(selectedActivities.value.map((it) => activityLabel(it))),
 );
 
 const copyBtnLabel = computed(() => {
-  const selectedCount = selectedActivities.value.length;
-  const selectionLabel = selectedCount
-    ? `${pluralize('item', selectedCount, true)}`
-    : '';
-  return `Copy ${selectionLabel} ${props.action === AddInto ? 'inside' : ''}`;
+  const { count, countLabel } = selectionSummary.value;
+  if (!count) return 'Copy';
+  return `Copy ${countLabel}${props.action === AddInto ? ' inside' : ''}`;
 });
 
 const selectRepository = async (repository: Repository) => {
@@ -134,17 +146,31 @@ const copyActivity = async (activity: Activity, prevActivity?: Activity) => {
   });
 };
 
+const activityLabel = (item?: Activity) => {
+  const source = selectedRepository.value?.activities?.find(
+    (it) => it.id === item?.id,
+  );
+  return (source && schemaApi.getActivityLabel(source)) || 'Item';
+};
+
 const copySelection = async () => {
   isCopyingActivities.value = true;
   const items = sortBy(selectedActivities.value, ['parentId', 'position']);
-  let prevOutlineItem: Activity | undefined;
-  for (const item of items) {
-    const copied = await copyActivity(item, prevOutlineItem);
-    prevOutlineItem = copied[0]; // Only first copied activity is outline item
+  const { noun, verb } = selectionSummary.value;
+  try {
+    let prevOutlineItem: Activity | undefined;
+    for (const item of items) {
+      const copied = await copyActivity(item, prevOutlineItem);
+      prevOutlineItem = copied[0]; // Only first copied activity is outline item
+    }
+    notify(`${upperFirst(noun)} ${verb} been copied`, { immediate: true });
+    emit('completed', items[0]?.parentId);
+    close();
+  } catch {
+    notify(`We couldn't copy ${noun}`, { color: 'error' });
+  } finally {
+    isCopyingActivities.value = false;
   }
-  emit('completed', items[0]?.parentId);
-  isCopyingActivities.value = false;
-  close();
 };
 
 const close = () => {

--- a/apps/frontend/app/components/repository/Outline/CreateDialog/index.vue
+++ b/apps/frontend/app/components/repository/Outline/CreateDialog/index.vue
@@ -59,14 +59,15 @@
 </template>
 
 <script lang="ts" setup>
-import { InsertLocation } from '@tailor-cms/utils';
 import type { Metadata } from '@tailor-cms/interfaces/schema';
+import { InsertLocation } from '@tailor-cms/utils';
 import { TailorDialog } from '@tailor-cms/core-components';
 import { useForm } from 'vee-validate';
+import pluralize from 'pluralize-esm';
 
+import type { StoreActivity } from '@/stores/activity';
 import TypeSelect from './TypeSelect.vue';
 import MetaInput from '@/components/common/MetaInput.vue';
-import type { StoreActivity } from '@/stores/activity';
 import { useActivityStore } from '@/stores/activity';
 import { useCurrentRepository } from '@/stores/current-repository';
 
@@ -93,10 +94,13 @@ const props = withDefaults(defineProps<Props>(), {
 
 const emit = defineEmits(['close', 'created', 'expand']);
 
+const { $schemaService, $i18n } = useNuxtApp() as any;
+
 const currentRepositoryStore = useCurrentRepository();
 const activityStore = useActivityStore();
 const selectedActivity = useSelectedActivity(props.anchor);
-const { $schemaService, $i18n } = useNuxtApp() as any;
+
+const notify = useNotification();
 
 // Check if i18n is enabled to show creation hint
 const showI18nHint = computed(() => $i18n?.isEnabled);
@@ -173,11 +177,16 @@ const submitForm = handleSubmit(async () => {
     action,
     anchor as StoreActivity,
   );
+  // Singularized - collection entity labels are plural
+  const label = pluralize.singular(
+    $schemaService.getActivityLabel(activity.value) || 'item',
+  );
   try {
     const item = (await activityStore.save(activity.value)) as StoreActivity;
     if (anchor && anchor.id === activity.value?.parentId) {
       selectedActivity.expandOutlineItemParent(item);
     }
+    notify(`A new ${label} has been created`, { immediate: true });
     emit('created', item);
     visible.value = false;
     if (props.openInEditor) {
@@ -188,6 +197,8 @@ const submitForm = handleSubmit(async () => {
     } else {
       currentRepositoryStore.selectActivity(item.id);
     }
+  } catch {
+    notify(`We couldn't create the ${label}`, { color: 'error' });
   } finally {
     submitting.value = false;
   }

--- a/apps/frontend/app/components/repository/Revisions/HistoryListItem.vue
+++ b/apps/frontend/app/components/repository/Revisions/HistoryListItem.vue
@@ -16,6 +16,7 @@
     <VListItemSubtitle
       v-tooltip:bottom="{ text: fullTimestamp, openDelay: 300 }"
       class="text-label-medium"
+      data-percy="hide"
     >
       {{ timeOfDay }} · {{ revision.user?.label ?? 'Unknown' }}
     </VListItemSubtitle>

--- a/apps/frontend/app/components/repository/Revisions/RevisionItem.vue
+++ b/apps/frontend/app/components/repository/Revisions/RevisionItem.vue
@@ -7,7 +7,10 @@
       @click="toggle"
     >
       <template #subtitle>
-        <span v-tooltip:bottom="{ text: fullTimestamp, openDelay: 300 }">
+        <span
+          v-tooltip:bottom="{ text: fullTimestamp, openDelay: 300 }"
+          data-percy="hide"
+        >
           {{ timeOfDay }} · {{ revision.user?.label }}
         </span>
       </template>

--- a/apps/frontend/app/components/repository/Settings/CloneModal.vue
+++ b/apps/frontend/app/components/repository/Settings/CloneModal.vue
@@ -1,12 +1,17 @@
 <template>
   <TailorDialog
     :model-value="show"
-    :title="`Clone ${target?.name}`"
+    :title="`Clone ${repositoryTypeLabel}`"
     header-icon="mdi-content-copy"
     persistent
     @submit="submit"
   >
     <template #body>
+      <p class="text-body-medium text-medium-emphasis mb-5">
+        You are about to clone the {{ repositoryTypeLabel }}
+        "{{ target?.name }}". Name the copy and adjust its description as
+        needed.
+      </p>
       <VTextField
         v-model="nameInput"
         :disabled="inProgress"
@@ -75,8 +80,8 @@ const target = computed(
   () => props.repository ?? currentRepositoryStore?.repository,
 );
 
-const repositoryTypeLabel = computed(
-  () => schemaApi.getSchema(target.value!.schema).name,
+const repositoryTypeLabel = computed(() =>
+  schemaApi.getLabel(target.value!),
 );
 
 const { defineField, errors, handleSubmit, resetForm } = useForm({
@@ -84,6 +89,11 @@ const { defineField, errors, handleSubmit, resetForm } = useForm({
     name: string().required().min(2).max(250),
     description: string().required().min(2).max(2000),
   }),
+  // The copy usually keeps the original description; the name must be new.
+  initialValues: {
+    name: '',
+    description: target.value?.description ?? '',
+  },
 });
 const [nameInput] = defineField('name');
 const [descriptionInput] = defineField('description');

--- a/apps/frontend/app/components/repository/Settings/CloneModal.vue
+++ b/apps/frontend/app/components/repository/Settings/CloneModal.vue
@@ -98,13 +98,13 @@ const submit = handleSubmit(async () => {
   try {
     const { id } = target.value!;
     await repositoryStore.clone(id, nameInput.value, descriptionInput.value);
-    notify(`The ${repositoryTypeLabel.value.toLowerCase()} has been cloned`, {
+    notify(`The ${repositoryTypeLabel.value} has been cloned`, {
       immediate: true,
     });
     emit('cloned');
     close();
   } catch {
-    notify(`We couldn't clone the ${repositoryTypeLabel.value.toLowerCase()}`, {
+    notify(`We couldn't clone the ${repositoryTypeLabel.value}`, {
       color: 'error',
     });
   } finally {

--- a/apps/frontend/app/components/repository/Settings/CloneModal.vue
+++ b/apps/frontend/app/components/repository/Settings/CloneModal.vue
@@ -45,8 +45,10 @@
 </template>
 
 <script lang="ts" setup>
-import { object, string } from 'yup';
 import type { Repository } from '@tailor-cms/interfaces/repository';
+
+import { object, string } from 'yup';
+import { schema as schemaApi } from '@tailor-cms/config';
 import { TailorDialog } from '@tailor-cms/core-components';
 import { useForm } from 'vee-validate';
 
@@ -57,16 +59,24 @@ const props = withDefaults(
   defineProps<{ show?: boolean; repository?: Repository }>(),
   { show: true },
 );
+
 const emit = defineEmits(['close', 'cloned']);
+
+const notify = useNotification();
 
 const repositoryStore = useRepositoryStore();
 const currentRepositoryStore = useCurrentRepository();
+
 const inProgress = ref(false);
 
 // Prefer an explicitly passed repository (e.g. from the catalog); fall back
 // to the loaded repository when used within the repository context.
 const target = computed(
   () => props.repository ?? currentRepositoryStore?.repository,
+);
+
+const repositoryTypeLabel = computed(
+  () => schemaApi.getSchema(target.value!.schema).name,
 );
 
 const { defineField, errors, handleSubmit, resetForm } = useForm({
@@ -85,11 +95,20 @@ const close = () => {
 
 const submit = handleSubmit(async () => {
   inProgress.value = true;
-  const { id } = target.value || {};
-  if (id) {
+  try {
+    const { id } = target.value!;
     await repositoryStore.clone(id, nameInput.value, descriptionInput.value);
+    notify(`The ${repositoryTypeLabel.value.toLowerCase()} has been cloned`, {
+      immediate: true,
+    });
     emit('cloned');
+    close();
+  } catch {
+    notify(`We couldn't clone the ${repositoryTypeLabel.value.toLowerCase()}`, {
+      color: 'error',
+    });
+  } finally {
+    inProgress.value = false;
   }
-  close();
 });
 </script>

--- a/apps/frontend/app/components/repository/Settings/ExportModal.vue
+++ b/apps/frontend/app/components/repository/Settings/ExportModal.vue
@@ -61,7 +61,7 @@ const exportRepository = () => {
   const url = `/api/repositories/${props.repository.id}/export/${jobId.value}`;
   window.open(url, '_blank');
   const type = schemaApi.getSchema(props.repository.schema).name;
-  notify(`The ${type.toLowerCase()} has been exported`, { immediate: true });
+  notify(`The ${type} has been exported`, { immediate: true });
   close();
 };
 

--- a/apps/frontend/app/components/repository/Settings/ExportModal.vue
+++ b/apps/frontend/app/components/repository/Settings/ExportModal.vue
@@ -1,12 +1,19 @@
 <template>
   <TailorDialog
     :model-value="true"
-    :title="`Export ${repository.name}`"
+    :title="`Export ${repositoryTypeLabel}`"
     header-icon="mdi-export"
     persistent
   >
     <template #body>
-      <VAlert v-bind="status" :text="status.message" variant="tonal" prominent />
+      <VAlert
+        :class="{ 'pa-0': !isError }"
+        :color="isError ? 'error' : undefined"
+        :icon="status.icon"
+        :text="status.message"
+        :variant="isError ? 'tonal' : 'text'"
+        prominent
+      />
     </template>
     <template #actions>
       <VBtn text="Cancel" variant="text" @click="close" />
@@ -34,25 +41,34 @@ const emit = defineEmits(['close']);
 
 const notify = useNotification();
 
-const STATUS = {
+const { name } = props.repository;
+const repositoryTypeLabel = schemaApi.getLabel(props.repository);
+
+interface ExportStatus {
+  icon: string;
+  message: string;
+  isError?: boolean;
+}
+
+const STATUS: Record<'INIT' | 'READY' | 'ERROR', ExportStatus> = {
   INIT: {
     icon: 'mdi-loading mdi-spin',
-    message: 'Please wait while repository export is being prepared...',
+    message: `Preparing the "${name}" export...`,
   },
   READY: {
     icon: 'mdi-download-circle-outline',
-    color: '',
-    message: 'Repository export is ready. Click button below to download...',
+    message: `The "${name}" export is ready to download.`,
   },
   ERROR: {
     icon: 'mdi-alert-circle-outline',
-    color: 'error',
+    isError: true,
     message: 'Something went wrong. Please try again later.',
   },
 };
 
 const jobId = ref<string | null>(null);
 const status = ref(STATUS.INIT);
+const isError = computed(() => !!status.value.isError);
 
 const exportRepository = () => {
   if (!jobId.value) return;
@@ -60,12 +76,11 @@ const exportRepository = () => {
   // so the browser handles the download natively
   const url = `/api/repositories/${props.repository.id}/export/${jobId.value}`;
   window.open(url, '_blank');
-  const type = schemaApi.getSchema(props.repository.schema).name;
-  notify(`The ${type} has been exported`, { immediate: true });
+  notify(`The ${repositoryTypeLabel} has been exported`, { immediate: true });
   close();
 };
 
-const setStatus = (val: { icon: string; color: string; message: string }) => {
+const setStatus = (val: ExportStatus) => {
   status.value = val;
 };
 

--- a/apps/frontend/app/components/repository/Settings/ExportModal.vue
+++ b/apps/frontend/app/components/repository/Settings/ExportModal.vue
@@ -23,12 +23,16 @@
 
 <script lang="ts" setup>
 import type { Repository } from '@tailor-cms/interfaces/repository';
+
+import { schema as schemaApi } from '@tailor-cms/config';
 import { TailorDialog } from '@tailor-cms/core-components';
 
 import { api } from '@/api';
 
 const props = defineProps<{ repository: Repository }>();
 const emit = defineEmits(['close']);
+
+const notify = useNotification();
 
 const STATUS = {
   INIT: {
@@ -56,6 +60,8 @@ const exportRepository = () => {
   // so the browser handles the download natively
   const url = `/api/repositories/${props.repository.id}/export/${jobId.value}`;
   window.open(url, '_blank');
+  const type = schemaApi.getSchema(props.repository.schema).name;
+  notify(`The ${type.toLowerCase()} has been exported`, { immediate: true });
   close();
 };
 

--- a/apps/frontend/app/composables/useCatalogPublish.ts
+++ b/apps/frontend/app/composables/useCatalogPublish.ts
@@ -1,4 +1,6 @@
 import type { Repository } from '@tailor-cms/interfaces/repository';
+
+import { schema as schemaApi } from '@tailor-cms/config';
 import Promise from 'bluebird';
 
 import { api } from '@/api';
@@ -14,6 +16,7 @@ const initialStatus = () => ({ progress: 0, message: '' });
  */
 export const useCatalogPublish = () => {
   const confirmationDialog = useConfirmationDialog();
+  const notify = useNotification();
 
   const status = ref(initialStatus());
   const isPublishing = computed(() => status.value.progress > 0);
@@ -33,14 +36,20 @@ export const useCatalogPublish = () => {
   };
 
   const publishRepository = (repository: Repository, onDone?: () => unknown) => {
+    const repositoryTypeName = schemaApi.getSchema(repository.schema).name;
     const message =
       `Are you sure you want to publish all content in ${repository.name}?`;
     confirmationDialog({
       title: 'Publish content',
       message,
       action: async () => {
-        await publish(repository.id);
-        await onDone?.();
+        try {
+          await publish(repository.id);
+          await onDone?.();
+          notify(`The ${repositoryTypeName} has been published`, { immediate: true });
+        } catch {
+          notify(`We couldn't publish the ${repositoryTypeName}`, { color: 'error' });
+        }
       },
     });
   };

--- a/apps/frontend/app/composables/useCatalogPublish.ts
+++ b/apps/frontend/app/composables/useCatalogPublish.ts
@@ -42,6 +42,7 @@ export const useCatalogPublish = () => {
       `Are you sure you want to publish the ${repositoryTypeLabel} "${name}"?`;
     confirmationDialog({
       title: `Publish ${repositoryTypeLabel}`,
+      icon: 'mdi-cloud-upload-outline',
       message,
       action: async () => {
         try {

--- a/apps/frontend/app/composables/useCatalogPublish.ts
+++ b/apps/frontend/app/composables/useCatalogPublish.ts
@@ -36,19 +36,20 @@ export const useCatalogPublish = () => {
   };
 
   const publishRepository = (repository: Repository, onDone?: () => unknown) => {
-    const repositoryTypeName = schemaApi.getSchema(repository.schema).name;
+    const { name } = repository;
+    const repositoryTypeLabel = schemaApi.getLabel(repository);
     const message =
-      `Are you sure you want to publish all content in ${repository.name}?`;
+      `Are you sure you want to publish the ${repositoryTypeLabel} "${name}"?`;
     confirmationDialog({
-      title: 'Publish content',
+      title: `Publish ${repositoryTypeLabel}`,
       message,
       action: async () => {
         try {
           await publish(repository.id);
           await onDone?.();
-          notify(`The ${repositoryTypeName} has been published`, { immediate: true });
+          notify(`The ${repositoryTypeLabel} has been published`, { immediate: true });
         } catch {
-          notify(`We couldn't publish the ${repositoryTypeName}`, { color: 'error' });
+          notify(`We couldn't publish the ${repositoryTypeLabel}`, { color: 'error' });
         }
       },
     });

--- a/apps/frontend/app/composables/useCollectionItemDeletion.ts
+++ b/apps/frontend/app/composables/useCollectionItemDeletion.ts
@@ -3,6 +3,7 @@ import { ReferenceDeletePolicy } from '@tailor-cms/interfaces/schema';
 import { useActivityStore } from '@/stores/activity';
 import { useConfirmationDialog } from '@/composables/useConfirmationDialog';
 import { useCurrentRepository } from '@/stores/current-repository';
+import pluralize from 'pluralize-esm';
 
 // A record that still references the item being deleted
 interface ReferencingRecord {
@@ -99,19 +100,27 @@ export function useCollectionItemDeletion() {
       cascades.length && `${summarize(cascades)} will also be deleted`,
       unlinks.length && `${summarize(unlinks)} will be unlinked`,
     ].filter(Boolean);
+
+    // Entity labels are plural (they name the collection list, e.g. "Tags")
+    const label = pluralize.singular(
+      $schemaService.getActivityLabel(item) ?? 'item',
+    );
     const message = impact.length
-      ? `Delete "${name}"? ${impact.join('; ')}.`
-      : `Are you sure you want to delete "${name}"?`;
+      ? `Delete the ${label} "${name}"? ${impact.join('; ')}.`
+      : `Are you sure you want to delete the ${label} "${name}"?`;
     confirm({
-      title: 'Delete item?',
+      title: `Delete ${label}?`,
       color: 'error',
       message,
       action: async () => {
         try {
           await activityStore.remove(item.id);
+          notify(`The ${label} has been deleted`, { immediate: true });
           onDeleted?.();
         } catch {
-          notify('Failed to delete item. It may still be referenced.');
+          const failure =
+            `We couldn't delete the ${label}. It may still be referenced.`;
+          notify(failure, { color: 'error' });
         }
       },
     });

--- a/apps/frontend/app/composables/useConfirmationDialog.ts
+++ b/apps/frontend/app/composables/useConfirmationDialog.ts
@@ -2,6 +2,7 @@ interface ConfirmationDialogOptions {
   title: string;
   message: string;
   color?: string;
+  icon?: string;
   action: () => any;
 }
 

--- a/apps/frontend/app/composables/usePublishActivity.ts
+++ b/apps/frontend/app/composables/usePublishActivity.ts
@@ -1,6 +1,8 @@
 import type { StoreActivity } from '@/stores/activity';
+
 import { schema as schemaApi } from '@tailor-cms/config';
 import Promise from 'bluebird';
+import pluralize from 'pluralize-esm';
 
 import { api } from '@/api';
 import { useActivityStore } from '@/stores/activity';
@@ -8,6 +10,9 @@ import { useCurrentRepository } from '@/stores/current-repository';
 
 const initialStatus = () => ({ progress: 0, message: '' });
 const prefix = (msg: string) => `Are you sure you want to publish ${msg}`;
+
+const activityLabel = (activity: StoreActivity) =>
+  pluralize.singular(schemaApi.getActivityLabel(activity) || 'item');
 
 export const usePublishActivity = (anchorActivity?: StoreActivity) => {
   const currentRepository = useCurrentRepository();
@@ -22,7 +27,7 @@ export const usePublishActivity = (anchorActivity?: StoreActivity) => {
     const activityCount = items.length;
     const totalActivities = currentRepository.outlineActivities.length;
     const activity = anchorActivity ?? items[0]!;
-    const label = schemaApi.getActivityLabel(activity) || 'item';
+    const label = activityLabel(activity);
     const target = `the ${label} "${activity.data.name}"`;
     if (activityCount === 1) return prefix(`${target}?`);
     if (activityCount === totalActivities) return prefix('all content?');
@@ -40,9 +45,10 @@ export const usePublishActivity = (anchorActivity?: StoreActivity) => {
 
   const confirmPublishing = (activities: StoreActivity[]) => {
     const activity = anchorActivity ?? activities[0]!;
-    const label = schemaApi.getActivityLabel(activity) || 'Item';
+    const label = activityLabel(activity);
     confirmationDialog({
-      title: 'Publish content',
+      title: `Publish ${label}`,
+      icon: 'mdi-cloud-upload-outline',
       message: getPublishMessage(activities),
       action: async () => {
         try {
@@ -56,21 +62,23 @@ export const usePublishActivity = (anchorActivity?: StoreActivity) => {
   };
 
   const publishRepository = (activities: StoreActivity[]) => {
-    const repositoryTypeName = currentRepository.schemaName || 'content';
+    const repositoryTypeLabel = currentRepository.schemaName;
+    const { name } = currentRepository.repository!;
     confirmationDialog({
-      title: 'Publish content',
-      message: getPublishMessage(activities),
+      title: `Publish ${repositoryTypeLabel}`,
+      icon: 'mdi-cloud-upload-outline',
+      message: `Are you sure you want to publish the ${repositoryTypeLabel} "${name}"?`,
       action: async () => {
         try {
           await api.repository.publishMeta({
             params: { repositoryId: currentRepository.repositoryId! },
           });
           await publish(activities.filter((it) => !it.detached));
-          notify(`The ${repositoryTypeName} has been published`, {
+          notify(`The ${repositoryTypeLabel} has been published`, {
             immediate: true,
           });
         } catch {
-          notify(`We couldn't publish the ${repositoryTypeName}`, {
+          notify(`We couldn't publish the ${repositoryTypeLabel}`, {
             color: 'error',
           });
         }

--- a/apps/frontend/app/composables/usePublishActivity.ts
+++ b/apps/frontend/app/composables/usePublishActivity.ts
@@ -1,6 +1,7 @@
+import type { StoreActivity } from '@/stores/activity';
+import { schema as schemaApi } from '@tailor-cms/config';
 import Promise from 'bluebird';
 
-import type { StoreActivity } from '@/stores/activity';
 import { api } from '@/api';
 import { useActivityStore } from '@/stores/activity';
 import { useCurrentRepository } from '@/stores/current-repository';
@@ -12,6 +13,7 @@ export const usePublishActivity = (anchorActivity?: StoreActivity) => {
   const currentRepository = useCurrentRepository();
   const activityStore = useActivityStore();
   const confirmationDialog = useConfirmationDialog();
+  const notify = useNotification();
 
   const status = ref(initialStatus());
   const isPublishing = computed(() => status.value.progress > 0);
@@ -19,9 +21,12 @@ export const usePublishActivity = (anchorActivity?: StoreActivity) => {
   const getPublishMessage = (items: StoreActivity[]) => {
     const activityCount = items.length;
     const totalActivities = currentRepository.outlineActivities.length;
-    if (activityCount === 1) return prefix(`${items[0]?.data.name} activity?`);
-    if (activityCount === totalActivities) return prefix('all activities?');
-    return prefix(`${anchorActivity?.data.name} and all its descendants?`);
+    const activity = anchorActivity ?? items[0]!;
+    const label = schemaApi.getActivityLabel(activity) || 'item';
+    const target = `the ${label} "${activity.data.name}"`;
+    if (activityCount === 1) return prefix(`${target}?`);
+    if (activityCount === totalActivities) return prefix('all content?');
+    return prefix(`${target} and all its descendants?`);
   };
 
   const publish = (activities: StoreActivity[]) => {
@@ -34,22 +39,41 @@ export const usePublishActivity = (anchorActivity?: StoreActivity) => {
   };
 
   const confirmPublishing = (activities: StoreActivity[]) => {
-    confirmationDialog({
-      title: 'Publish content',
-      message: getPublishMessage(activities),
-      action: () => publish(activities.filter((it) => !it.detached)),
-    });
-  };
-
-  const publishRepository = (activities: StoreActivity[]) => {
+    const activity = anchorActivity ?? activities[0]!;
+    const label = schemaApi.getActivityLabel(activity) || 'Item';
     confirmationDialog({
       title: 'Publish content',
       message: getPublishMessage(activities),
       action: async () => {
-        await api.repository.publishMeta({
-          params: { repositoryId: currentRepository.repositoryId! },
-        });
-        await publish(activities.filter((it) => !it.detached));
+        try {
+          await publish(activities.filter((it) => !it.detached));
+          notify(`The ${label} has been published`, { immediate: true });
+        } catch {
+          notify(`We couldn't publish the ${label}`, { color: 'error' });
+        }
+      },
+    });
+  };
+
+  const publishRepository = (activities: StoreActivity[]) => {
+    const repositoryTypeName = currentRepository.schemaName || 'content';
+    confirmationDialog({
+      title: 'Publish content',
+      message: getPublishMessage(activities),
+      action: async () => {
+        try {
+          await api.repository.publishMeta({
+            params: { repositoryId: currentRepository.repositoryId! },
+          });
+          await publish(activities.filter((it) => !it.detached));
+          notify(`The ${repositoryTypeName} has been published`, {
+            immediate: true,
+          });
+        } catch {
+          notify(`We couldn't publish the ${repositoryTypeName}`, {
+            color: 'error',
+          });
+        }
       },
     });
   };

--- a/apps/frontend/app/layouts/main.vue
+++ b/apps/frontend/app/layouts/main.vue
@@ -5,7 +5,6 @@
       <slot></slot>
     </VMain>
     <ConfirmationDialog />
-    <NotificationSnackbar />
     <UploadIndicator />
   </div>
 </template>
@@ -13,7 +12,6 @@
 <script lang="ts" setup>
 import AppBar from '@/components/common/AppBar.vue';
 import ConfirmationDialog from '@/components/common/ConfirmationDialog.vue';
-import NotificationSnackbar from '@/components/common/NotificationSnackbar.vue';
 import UploadIndicator from '@/components/common/UploadIndicator.vue';
 import { useAuthStore } from '@/stores/auth';
 

--- a/apps/frontend/app/pages/index.vue
+++ b/apps/frontend/app/pages/index.vue
@@ -142,7 +142,7 @@
 <script setup lang="ts">
 import type { Repository } from '@tailor-cms/interfaces/repository';
 
-import { find, map, uniq, upperFirst } from 'lodash-es';
+import { find, map, upperFirst } from 'lodash-es';
 import { SCHEMAS, schema as schemaApi } from '@tailor-cms/config';
 import { TailorEmptyState } from '@tailor-cms/core-components';
 import { storeToRefs } from 'pinia';
@@ -163,6 +163,7 @@ import RepositoryFilterSelection
 import SearchInput from '@/components/catalog/Filter/SearchInput.vue';
 import SelectOrder from '@/components/catalog/Filter/SelectOrder.vue';
 import UserGroupSelect from '@/components/catalog/Filter/UserGroupSelect.vue';
+import { describeSelection } from '@/utils/describeSelection';
 import { useAuthStore } from '@/stores/auth';
 import { useConfirmationDialog } from '@/composables/useConfirmationDialog';
 import { useConfigStore } from '@/stores/config';
@@ -234,12 +235,9 @@ const deleteSelected = () => {
   const selected = repositories.value.filter((it) =>
     selectedRepos.value.has(it.id),
   );
-  const count = selected.length;
-  const types = uniq(
+  const { count, label, noun, verb } = describeSelection(
     selected.map((it) => schemaApi.getLabel(it)),
   );
-  const label = types.length === 1 ? types[0]! : 'item';
-  const noun = count === 1 ? `the ${label}` : `${count} ${pluralize(label)}`;
   const target = count === 1 ? `${noun} "${selected[0]!.name}"` : noun;
 
   confirmationDialog({
@@ -252,7 +250,6 @@ const deleteSelected = () => {
         await Promise.each(selected, ({ id }: Repository) =>
           repositoryStore.remove(id),
         );
-        const verb = count === 1 ? 'has' : 'have';
         notify(`${upperFirst(noun)} ${verb} been deleted`, { immediate: true });
       } catch {
         notify(`We couldn't delete the selected ${pluralize(label)}`, {

--- a/apps/frontend/app/pages/index.vue
+++ b/apps/frontend/app/pages/index.vue
@@ -140,14 +140,14 @@
 </template>
 
 <script setup lang="ts">
-import { find, map } from 'lodash-es';
-import { SCHEMAS } from '@tailor-cms/config';
+import type { Repository } from '@tailor-cms/interfaces/repository';
+
+import { find, map, uniq, upperFirst } from 'lodash-es';
+import { SCHEMAS, schema as schemaApi } from '@tailor-cms/config';
 import { TailorEmptyState } from '@tailor-cms/core-components';
 import { storeToRefs } from 'pinia';
 import pluralize from 'pluralize-esm';
 import Promise from 'bluebird';
-
-import type { Repository } from '@tailor-cms/interfaces/repository';
 
 import AddRepository from '@/components/catalog/AddRepository/index.vue';
 import BulkActionBar from '@/components/catalog/BulkActionBar.vue';
@@ -181,8 +181,10 @@ useHead({
 const authStore = useAuthStore();
 const repositoryStore = useRepositoryStore();
 const config = useConfigStore();
-const confirmationDialog = useConfirmationDialog();
+
 const publishUtils = useCatalogPublish();
+const confirmationDialog = useConfirmationDialog();
+const notify = useNotification();
 
 const isLoading = ref(true);
 const isDeleting = ref(false);
@@ -229,17 +231,33 @@ const toggleSelectAll = () => {
 };
 
 const deleteSelected = () => {
-  const count = selectedRepos.value.size;
+  const selected = repositories.value.filter((it) =>
+    selectedRepos.value.has(it.id),
+  );
+  const count = selected.length;
+  const types = uniq(
+    selected.map((it) => schemaApi.getLabel(it)),
+  );
+  const label = types.length === 1 ? types[0]! : 'item';
+  const noun = count === 1 ? `the ${label}` : `${count} ${pluralize(label)}`;
+  const target = count === 1 ? `${noun} "${selected[0]!.name}"` : noun;
 
   confirmationDialog({
-    title: `Delete ${pluralize('repository', count)}?`,
+    title: `Delete ${pluralize(label, count)}?`,
     color: 'error',
-    message: `Are you sure you want to delete ${pluralize('repository', count, true)}?`,
+    message: `Are you sure you want to delete ${target}?`,
     action: async () => {
       isDeleting.value = true;
       try {
-        const repositories = Array.from(selectedRepos.value);
-        await Promise.each(repositories, (id) => repositoryStore.remove(id));
+        await Promise.each(selected, ({ id }: Repository) =>
+          repositoryStore.remove(id),
+        );
+        const verb = count === 1 ? 'has' : 'have';
+        notify(`${upperFirst(noun)} ${verb} been deleted`, { immediate: true });
+      } catch {
+        notify(`We couldn't delete the selected ${pluralize(label)}`, {
+          color: 'error',
+        });
       } finally {
         selectedRepos.value.clear();
         await refetchRepositories();
@@ -262,13 +280,19 @@ const onCardPublish = (repository: Repository) => {
 };
 
 const deleteRepository = (repository: Repository) => {
+  const type = schemaApi.getLabel(repository);
   confirmationDialog({
-    title: 'Delete repository?',
+    title: `Delete ${type}?`,
     color: 'error',
-    message: `Are you sure you want to delete repository ${repository.name}?`,
+    message: `Are you sure you want to delete the ${type} "${repository.name}"?`,
     action: async () => {
-      await repositoryStore.remove(repository.id);
-      await refetchRepositories();
+      try {
+        await repositoryStore.remove(repository.id);
+        notify(`The ${type} has been deleted`, { immediate: true });
+        await refetchRepositories();
+      } catch {
+        notify(`We couldn't delete the ${type}`, { color: 'error' });
+      }
     },
   });
 };

--- a/apps/frontend/app/pages/repository/[[id]].vue
+++ b/apps/frontend/app/pages/repository/[[id]].vue
@@ -68,6 +68,7 @@ const isLoading = ref(true);
 const repositoryStore = useRepositoryStore();
 const publishUtils = usePublishActivity();
 const confirmationDialog = useConfirmationDialog();
+const notify = useNotification();
 
 const showCloneModal = ref(false);
 const showExportModal = ref(false);
@@ -76,16 +77,20 @@ const publishPercentage = computed(
 );
 
 const showDeleteConfirmation = () => {
-  const repository = currentRepositoryStore.repository as Repository;
-  if (!repository) return;
-  const { id, name } = repository;
+  const { id, name } = currentRepositoryStore.repository as Repository;
+  const type = currentRepositoryStore.schemaName;
   confirmationDialog({
-    title: 'Delete repository?',
+    title: `Delete ${type}?`,
     color: 'error',
-    message: `Are you sure you want to delete repository ${name}?`,
+    message: `Are you sure you want to delete the ${type} "${name}"?`,
     action: async () => {
-      await repositoryStore.remove(id);
-      navigateTo('/');
+      try {
+        await repositoryStore.remove(id);
+        notify(`The ${type} has been deleted`, { immediate: true });
+        navigateTo('/');
+      } catch {
+        notify(`We couldn't delete the ${type}`, { color: 'error' });
+      }
     },
   });
 };

--- a/apps/frontend/app/utils/describeSelection.ts
+++ b/apps/frontend/app/utils/describeSelection.ts
@@ -1,0 +1,21 @@
+import { uniq } from 'lodash-es';
+import pluralize from 'pluralize-esm';
+
+/**
+ * Grammar bits for messages about a selection of typed items ("The Module
+ * has been copied", "2 Pages have been linked", "Delete 3 Courses?").
+ * Selections spanning multiple types fall back to a generic "item".
+ */
+export const describeSelection = (labels: string[]) => {
+  const count = labels.length;
+  const types = uniq(labels);
+  // Normalize to singular - collection entity labels are plural (e.g. "Tags")
+  const label = types.length === 1 ? pluralize.singular(types[0]!) : 'item';
+  return {
+    count,
+    label,
+    countLabel: pluralize(label, count, true),
+    noun: count === 1 ? `the ${label}` : `${count} ${pluralize(label)}`,
+    verb: count === 1 ? 'has' : 'have',
+  };
+};

--- a/packages/tailor-config-parser/src/schema.ts
+++ b/packages/tailor-config-parser/src/schema.ts
@@ -119,6 +119,7 @@ export const getSchemaApi = (schemas: Schema[], ceRegistry: string[]) => {
     filterOutlineActivities,
     isTrackedInWorkflow,
     getRepositoryMetadata,
+    getLabel,
     getActivityLabel,
     getActivityMetadata,
     getElementMetadata,
@@ -254,6 +255,11 @@ export const getSchemaApi = (schemas: Schema[], ceRegistry: string[]) => {
 
   function getActivityLabel(activity: Activity) {
     return getActivityConfig(activity.type).label;
+  }
+
+  // The repository's user-facing type label (e.g. "Course")
+  function getLabel(repository: Repository) {
+    return getSchema(repository.schema).name;
   }
 
   function getActivityMetadata(activity: Activity) {

--- a/tests/fixtures/auth.ts
+++ b/tests/fixtures/auth.ts
@@ -1,5 +1,5 @@
 import { find } from 'lodash-es';
-import seed from 'tailor-seed/user.json' assert { type: 'json' };
+import seed from 'tailor-seed/user.json' with { type: 'json' };
 
 const adminTestUser = find(seed, { email: 'admin@gostudion.com' });
 if (!adminTestUser) throw new Error('Admin test user not found');

--- a/tests/pom/catalog/AddRepository.ts
+++ b/tests/pom/catalog/AddRepository.ts
@@ -13,7 +13,7 @@ export class AddRepositoryDialog {
   readonly nameInput: Locator;
   readonly descriptionInput: Locator;
   readonly archiveInput: Locator;
-  readonly createRepositoryBtn: Locator;
+  readonly submitBtn: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -30,7 +30,10 @@ export class AddRepositoryDialog {
     this.nameInput = dialog.getByLabel('Name');
     this.descriptionInput = dialog.getByLabel('Description');
     this.archiveInput = dialog.locator('input[name="archive"]');
-    this.createRepositoryBtn = dialog.getByRole('button', { name: 'Create' });
+    // Submit follows the active tab: "Create" on New, "Import" on Import
+    this.submitBtn = dialog.getByRole('button', {
+      name: /^(Create|Import)$/,
+    });
   }
 
   async open() {
@@ -39,7 +42,7 @@ export class AddRepositoryDialog {
     return this.emptyCreateCard.click();
   }
 
-  async createRepository(
+  async submitCreate(
     type = 'Course',
     name = `${faker.lorem.words(2)} ${new Date().getTime()}`,
     description = faker.lorem.words(4),
@@ -48,12 +51,11 @@ export class AddRepositoryDialog {
     await this.selectRepositoryType(type);
     await this.nameInput.fill(name);
     await this.descriptionInput.fill(description);
-    await this.createRepositoryBtn.click();
-    await expect(this.page.getByText(name)).toBeVisible();
+    await this.submitBtn.click();
     return { type, name, description };
   }
 
-  async importRepository(
+  async submitImport(
     name = `${faker.lorem.words(2)} ${new Date().getTime()}`,
     description = faker.lorem.words(4),
     archive = './fixtures/pizza.tgz',
@@ -64,9 +66,28 @@ export class AddRepositoryDialog {
     await this.archiveInput.setInputFiles(archive);
     await this.nameInput.fill(name);
     await this.descriptionInput.fill(description);
-    await this.createRepositoryBtn.click();
-    await this.page.waitForTimeout(5000);
+    await this.submitBtn.click();
     return { name, description };
+  }
+
+  async createRepository(
+    type = 'Course',
+    name = `${faker.lorem.words(2)} ${new Date().getTime()}`,
+    description = faker.lorem.words(4),
+  ) {
+    const result = await this.submitCreate(type, name, description);
+    await expect(this.page.getByText(name)).toBeVisible();
+    return result;
+  }
+
+  async importRepository(
+    name = `${faker.lorem.words(2)} ${new Date().getTime()}`,
+    description = faker.lorem.words(4),
+    archive = './fixtures/pizza.tgz',
+  ) {
+    const result = await this.submitImport(name, description, archive);
+    await this.page.waitForTimeout(5000);
+    return result;
   }
 
   async selectRepositoryType(type: string) {

--- a/tests/pom/catalog/Catalog.ts
+++ b/tests/pom/catalog/Catalog.ts
@@ -1,5 +1,7 @@
 import type { Locator, Page } from '@playwright/test';
 
+import { confirmAction } from '../common/utils';
+
 export class Catalog {
   static route = '/';
   readonly page: Page;
@@ -101,5 +103,11 @@ export class Catalog {
   async toggleRepository(hasText: string) {
     await this.findRepositoryCard(hasText).hover();
     await this.getCardCheckbox(hasText).click();
+  }
+
+  async bulkDelete(...names: string[]) {
+    for (const name of names) await this.toggleRepository(name);
+    await this.deleteSelectedBtn.click();
+    await confirmAction(this.page);
   }
 }

--- a/tests/pom/catalog/RepositoryCard.ts
+++ b/tests/pom/catalog/RepositoryCard.ts
@@ -1,17 +1,37 @@
 import type { Locator, Page } from '@playwright/test';
 import { expect } from '@playwright/test';
 
+import { confirmAction, selectMenuOption } from '../common/utils';
+
 export class RepositoryCard {
   readonly page: Page;
   readonly el: Locator;
   readonly addTagBtn: Locator;
   readonly pinBtn: Locator;
+  readonly actionsBtn: Locator;
 
   constructor(page: Page, el: Locator) {
     this.page = page;
     this.el = el;
     this.addTagBtn = el.getByLabel('Add tag');
     this.pinBtn = el.getByLabel('Pin repository');
+    this.actionsBtn = el.getByLabel('Repository actions');
+  }
+
+  async runAction(name: 'Clone' | 'Publish' | 'Export' | 'Delete') {
+    await this.actionsBtn.click();
+    await selectMenuOption(this.page, name);
+  }
+
+  async publish() {
+    await this.runAction('Publish');
+    const dialog = this.page.locator('div[role="dialog"]');
+    await dialog.getByRole('button', { name: 'Confirm' }).click();
+  }
+
+  async delete() {
+    await this.runAction('Delete');
+    await confirmAction(this.page);
   }
 
   togglePin() {

--- a/tests/pom/common/Toast.ts
+++ b/tests/pom/common/Toast.ts
@@ -25,4 +25,46 @@ export class Toast {
   waitForDismiss() {
     return expect(this.el).not.toBeVisible();
   }
+
+  // Named confirmation toasts
+  expectCreated(label: string) {
+    return this.hasText(`A new ${label} has been created`);
+  }
+
+  expectImportSucceeded() {
+    return this.hasText('Import successful');
+  }
+
+  expectCloned(label: string) {
+    return this.expectConfirmed(label, 'cloned');
+  }
+
+  expectCopied(label: string) {
+    return this.expectConfirmed(label, 'copied');
+  }
+
+  expectLinked(label: string) {
+    return this.expectConfirmed(label, 'linked');
+  }
+
+  expectPublished(label: string) {
+    return this.expectConfirmed(label, 'published');
+  }
+
+  expectExported(label: string) {
+    return this.expectConfirmed(label, 'exported');
+  }
+
+  expectDeleted(label: string) {
+    return this.expectConfirmed(label, 'deleted');
+  }
+
+  // Bulk variant, e.g. expectDeletedMany('2 Courses')
+  expectDeletedMany(countLabel: string) {
+    return this.hasText(`${countLabel} have been deleted`);
+  }
+
+  private expectConfirmed(label: string, verb: string) {
+    return this.hasText(`The ${label} has been ${verb}`);
+  }
 }

--- a/tests/pom/common/utils.ts
+++ b/tests/pom/common/utils.ts
@@ -12,6 +12,13 @@ export const confirmAction = async (
   await expect(dialog).not.toBeVisible();
 };
 
+// Pick an entry from the topmost overlay menu
+export const selectMenuOption = async (page: Page, name: string) => {
+  const menu = page.locator('.v-overlay.v-menu').last();
+  await expect(menu).toBeVisible();
+  await menu.locator('.v-list-item-title').filter({ hasText: name }).click();
+};
+
 export const expectAlert = async (page: Page, message: string) => {
   const toast = new Toast(page);
   await toast.hasText(message);

--- a/tests/pom/repository/CloneDialog.ts
+++ b/tests/pom/repository/CloneDialog.ts
@@ -1,0 +1,45 @@
+import type { Locator, Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+
+export class CloneDialog {
+  readonly page: Page;
+  readonly el: Locator;
+  readonly nameInput: Locator;
+  readonly descriptionInput: Locator;
+  readonly cloneBtn: Locator;
+  readonly cancelBtn: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.el = page.locator('div[role="dialog"]', {
+      hasText: 'You are about to clone',
+    });
+    this.nameInput = this.el.getByLabel('Name');
+    this.descriptionInput = this.el.getByLabel('Description');
+    this.cloneBtn = this.el.getByRole('button', { name: 'Clone' });
+    this.cancelBtn = this.el.getByRole('button', { name: 'Cancel' });
+  }
+
+  expectTitle(title: string) {
+    return expect(this.el.getByText(title, { exact: true })).toBeVisible();
+  }
+
+  // The description is prefilled from the source repository
+  expectDescriptionPrefilled() {
+    return expect(this.descriptionInput).toHaveValue(/.+/);
+  }
+
+  async clone(name: string, description?: string) {
+    await this.nameInput.fill(name);
+    // Submitting without a description relies on the prefilled source value
+    if (description) await this.descriptionInput.fill(description);
+    else await this.expectDescriptionPrefilled();
+    await this.cloneBtn.click();
+    await expect(this.el).not.toBeVisible();
+  }
+
+  async cancel() {
+    await this.cancelBtn.click();
+    await expect(this.el).not.toBeVisible();
+  }
+}

--- a/tests/pom/repository/CopyActivityDialog.ts
+++ b/tests/pom/repository/CopyActivityDialog.ts
@@ -2,16 +2,16 @@ import type { Page } from '@playwright/test';
 
 import { SourceContentDialog } from './SourceContentDialog';
 
-export class LinkContentDialog extends SourceContentDialog {
+export class CopyActivityDialog extends SourceContentDialog {
   constructor(page: Page) {
-    super(page, { title: 'Link existing content', action: /^Link/ });
+    super(page, { title: 'Copy existing', action: /^Copy/ });
   }
 
-  link() {
+  copy() {
     return this.submitSelection();
   }
 
-  selectAndLink(repositoryName: string, activityName: string) {
+  selectAndCopy(repositoryName: string, activityName: string) {
     return this.selectAndSubmit(repositoryName, activityName);
   }
 }

--- a/tests/pom/repository/ExportDialog.ts
+++ b/tests/pom/repository/ExportDialog.ts
@@ -1,0 +1,27 @@
+import type { Locator, Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+
+export class ExportDialog {
+  readonly page: Page;
+  readonly el: Locator;
+  readonly downloadBtn: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.el = page.locator('div[role="dialog"]', { hasText: 'export' });
+    this.downloadBtn = this.el.getByRole('button', { name: 'Download' });
+  }
+
+  // Wait for the export job to finish, then download the archive
+  async download() {
+    await expect(this.el.getByText(/export is ready/i)).toBeVisible({
+      timeout: 10000,
+    });
+    const downloadEvent = this.page.waitForEvent('download');
+    await this.downloadBtn.click();
+    const download = await downloadEvent;
+    const path = `tmp/${download.suggestedFilename()}`;
+    await download.saveAs(path);
+    return path;
+  }
+}

--- a/tests/pom/repository/NavigationRail.ts
+++ b/tests/pom/repository/NavigationRail.ts
@@ -3,6 +3,7 @@ import { expect } from '@playwright/test';
 
 import { confirmAction, selectMenuOption } from '../common/utils';
 import { CloneDialog } from './CloneDialog';
+import { ExportDialog } from './ExportDialog';
 
 type RailAction = 'Clone' | 'Publish' | 'Export' | 'Delete';
 
@@ -76,16 +77,7 @@ export class NavigationRail {
 
   async export() {
     await this.runAction('Export');
-    const dialog = this.page.locator('div[role="dialog"]');
-    await expect(dialog.getByText(/export is ready/i)).toBeVisible({
-      timeout: 10000,
-    });
-    const downloadEvent = this.page.waitForEvent('download');
-    await dialog.getByRole('button', { name: 'Download' }).click();
-    const download = await downloadEvent;
-    const path = `tmp/${download.suggestedFilename()}`;
-    await download.saveAs(path);
-    return path;
+    return new ExportDialog(this.page).download();
   }
 
   async delete() {

--- a/tests/pom/repository/NavigationRail.ts
+++ b/tests/pom/repository/NavigationRail.ts
@@ -1,6 +1,9 @@
 import type { Locator, Page } from '@playwright/test';
 import { expect } from '@playwright/test';
 
+import { confirmAction, selectMenuOption } from '../common/utils';
+import { CloneDialog } from './CloneDialog';
+
 type RailAction = 'Clone' | 'Publish' | 'Export' | 'Delete';
 
 export class NavigationRail {
@@ -51,25 +54,14 @@ export class NavigationRail {
     return this.getTab('Settings').click();
   }
 
-  async openActionsMenu() {
-    await this.actionsMenuBtn.click();
-    const menu = this.page.locator('.v-overlay.v-menu').last();
-    await expect(menu).toBeVisible();
-    return menu;
-  }
-
   async runAction(name: RailAction) {
-    const menu = await this.openActionsMenu();
-    await menu.locator('.v-list-item-title').filter({ hasText: name }).click();
+    await this.actionsMenuBtn.click();
+    await selectMenuOption(this.page, name);
   }
 
   async clone(name = 'Cloned repository') {
     await this.runAction('Clone');
-    const dialog = this.page.locator('div[role="dialog"]');
-    await dialog.getByLabel('Name').fill(name);
-    await dialog.getByLabel('Description').fill('Test description');
-    await dialog.getByRole('button', { name: 'Clone' }).click();
-    await expect(dialog).not.toBeVisible();
+    await new CloneDialog(this.page).clone(name);
   }
 
   async publish() {
@@ -85,7 +77,7 @@ export class NavigationRail {
   async export() {
     await this.runAction('Export');
     const dialog = this.page.locator('div[role="dialog"]');
-    await expect(dialog.getByText('Repository export is ready.')).toBeVisible({
+    await expect(dialog.getByText(/export is ready/i)).toBeVisible({
       timeout: 10000,
     });
     const downloadEvent = this.page.waitForEvent('download');
@@ -98,7 +90,6 @@ export class NavigationRail {
 
   async delete() {
     await this.runAction('Delete');
-    const dialog = this.page.locator('div[role="dialog"]');
-    await dialog.getByRole('button', { name: 'confirm' }).click();
+    await confirmAction(this.page);
   }
 }

--- a/tests/pom/repository/Outline.ts
+++ b/tests/pom/repository/Outline.ts
@@ -2,6 +2,7 @@ import type { Locator, Page } from '@playwright/test';
 import { expect } from '@playwright/test';
 
 import { AddItemDialog } from './AddItemDialog';
+import { CopyActivityDialog } from './CopyActivityDialog';
 import { LinkContentDialog } from './LinkContentDialog';
 import { OutlineItem } from './OutlineItem';
 import { OutlineSidebar } from './OutlineSidebar';
@@ -89,5 +90,17 @@ export class ActivityOutline {
   async linkFirst() {
     await this.emptyLinkCard.click();
     return new LinkContentDialog(this.page);
+  }
+
+  async copyExisting() {
+    await this.addMenuBtn.waitFor({ state: 'visible' });
+    await this.addMenuBtn.click();
+    await this.page.getByText('Copy existing', { exact: true }).click();
+    return new CopyActivityDialog(this.page);
+  }
+
+  async copyFirst() {
+    await this.emptyCopyCard.click();
+    return new CopyActivityDialog(this.page);
   }
 }

--- a/tests/pom/repository/OutlineSidebar.ts
+++ b/tests/pom/repository/OutlineSidebar.ts
@@ -1,6 +1,7 @@
 import { type Locator, type Page, expect } from '@playwright/test';
 
 import { Comments } from '../common/Comments';
+import { confirmAction } from '../common/utils';
 import { FileInput } from '../common/FileInput';
 import { LinkedCopyNotice } from './LinkedCopyNotice';
 import { LinkedIndicator } from './LinkedIndicator';
@@ -50,6 +51,14 @@ export class OutlineSidebar {
     // Confirm publish
     const dialog = this.page.locator('div[role="dialog"]');
     await dialog.getByRole('button', { name: 'confirm' }).click();
+  }
+
+  async remove() {
+    await this.el.getByLabel('Options menu').click();
+    await this.page.locator('.activity-menu').getByLabel('Remove').click();
+    const message = this.page.getByText('Are you sure you want to delete');
+    await expect(message).toBeVisible();
+    await confirmAction(this.page);
   }
 
   getMetaInput(placeholder: string): Locator {

--- a/tests/pom/repository/SourceContentDialog.ts
+++ b/tests/pom/repository/SourceContentDialog.ts
@@ -1,0 +1,61 @@
+import type { Locator, Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+
+interface DialogConfig {
+  title: string;
+  action: RegExp;
+}
+
+// Base for the copy/link dialogs - both pick a source repository, then
+// activities from its tree, and submit the selection.
+export class SourceContentDialog {
+  readonly page: Page;
+  readonly el: Locator;
+  readonly repositoryInput: Locator;
+  readonly submitBtn: Locator;
+  readonly cancelBtn: Locator;
+
+  constructor(page: Page, { title, action }: DialogConfig) {
+    this.page = page;
+    this.el = page.locator('div[role="dialog"]', { hasText: title });
+    this.repositoryInput = this.el.getByPlaceholder(/^Type to search/);
+    this.submitBtn = this.el
+      .locator('.v-card-actions')
+      .getByRole('button', { name: action });
+    this.cancelBtn = this.el.getByRole('button', { name: 'Cancel' });
+  }
+
+  async selectRepository(name: string) {
+    await this.repositoryInput.click();
+    await this.repositoryInput.fill(name);
+    const option = this.page.getByRole('option', { name });
+    await expect(option.first()).toBeVisible();
+    await option.first().click();
+    // Wait for the source activity tree to load
+    await expect(this.el.locator('.v-treeview')).toBeVisible();
+  }
+
+  async selectActivity(name: string) {
+    const treeItem = this.el.locator('.v-treeview-item', { hasText: name });
+    await expect(treeItem).toBeVisible();
+    await treeItem.locator('.activity-select-checkbox').click();
+  }
+
+  async submitSelection() {
+    await expect(this.submitBtn).toBeEnabled();
+    await this.submitBtn.click();
+    // Wait for the dialog to close
+    await expect(this.el).not.toBeVisible();
+  }
+
+  async selectAndSubmit(repositoryName: string, activityName: string) {
+    await this.selectRepository(repositoryName);
+    await this.selectActivity(activityName);
+    await this.submitSelection();
+  }
+
+  async cancel() {
+    await this.cancelBtn.click();
+    await expect(this.el).not.toBeVisible();
+  }
+}

--- a/tests/specs/functional/admin/user-management.spec.ts
+++ b/tests/specs/functional/admin/user-management.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { times } from 'lodash-es';
-import userSeed from 'tailor-seed/user.json' assert { type: 'json' };
+import userSeed from 'tailor-seed/user.json' with { type: 'json' };
 
 import {
   UserDialog,

--- a/tests/specs/functional/catalog/catalog.spec.ts
+++ b/tests/specs/functional/catalog/catalog.spec.ts
@@ -3,7 +3,11 @@ import mockRepositories from 'tailor-seed/repositories.json' assert { type: 'jso
 
 import { AddRepositoryDialog } from '../../../pom/catalog/AddRepository';
 import { Catalog } from '../../../pom/catalog/Catalog';
+import { CloneDialog } from '../../../pom/repository/CloneDialog';
+import { createCleanRepository } from '../../../helpers/seed';
+import { ExportDialog } from '../../../pom/repository/ExportDialog';
 import { RepositoryCard } from '../../../pom/catalog/RepositoryCard';
+import { Toast } from '../../../pom/common/Toast';
 import SeedClient from '../../../api/SeedClient';
 
 test.beforeEach(async ({ page }) => {
@@ -25,14 +29,89 @@ test('should be able to create a new repository', async ({ page }) => {
   const dialog = new AddRepositoryDialog(page);
   await dialog.open();
   await dialog.createRepository();
+  await new Toast(page).expectCreated('Course');
 });
 
 test('should be able to import a repository', async ({ page }) => {
   const dialog = new AddRepositoryDialog(page);
   await dialog.open();
-  const { name } = await dialog.importRepository();
+  const { name } = await dialog.submitImport();
+  await new Toast(page).expectImportSucceeded();
   await page.reload();
   await expect(page.getByText(name)).toBeVisible({ timeout: 10000 });
+});
+
+test('should be able to publish a repository from its card', async ({
+  page,
+}) => {
+  const { data } = await SeedClient.seedTestRepository();
+  await page.reload();
+  const catalog = new Catalog(page);
+  const card = new RepositoryCard(
+    page,
+    catalog.findRepositoryCard(data.repository.name),
+  );
+  await card.publish();
+  await new Toast(page).expectPublished('Course');
+  await expect(card.el.getByLabel('Published')).toBeVisible();
+});
+
+test('should be able to clone a repository from its card', async ({
+  page,
+}) => {
+  const { data } = await SeedClient.seedTestRepository();
+  await page.reload();
+  const catalog = new Catalog(page);
+  const card = new RepositoryCard(
+    page,
+    catalog.findRepositoryCard(data.repository.name),
+  );
+  await card.runAction('Clone');
+  const cloneDialog = new CloneDialog(page);
+  await cloneDialog.expectTitle('Clone Course');
+  await cloneDialog.clone('Cloned From Card');
+  await new Toast(page).expectCloned('Course');
+  await expect(catalog.findRepositoryCard('Cloned From Card')).toBeVisible();
+});
+
+test('should be able to export a repository from its card', async ({
+  page,
+}) => {
+  const { data } = await SeedClient.seedTestRepository();
+  await page.reload();
+  const catalog = new Catalog(page);
+  const card = new RepositoryCard(
+    page,
+    catalog.findRepositoryCard(data.repository.name),
+  );
+  await card.runAction('Export');
+  await new ExportDialog(page).download();
+  await new Toast(page).expectExported('Course');
+});
+
+test('should be able to delete a repository from its card', async ({
+  page,
+}) => {
+  const { data } = await SeedClient.seedTestRepository();
+  await page.reload();
+  const catalog = new Catalog(page);
+  const card = new RepositoryCard(
+    page,
+    catalog.findRepositoryCard(data.repository.name),
+  );
+  await card.delete();
+  await new Toast(page).expectDeleted('Course');
+  await expect(page.getByText('No repositories yet')).toBeVisible();
+});
+
+test('should be able to bulk delete repositories', async ({ page }) => {
+  await createCleanRepository('Bulk Delete A');
+  await createCleanRepository('Bulk Delete B');
+  await page.reload();
+  const catalog = new Catalog(page);
+  await catalog.bulkDelete('Bulk Delete A', 'Bulk Delete B');
+  await new Toast(page).expectDeletedMany('2 Courses');
+  await expect(page.getByText('No repositories yet')).toBeVisible();
 });
 
 test('should be able to load repositories', async ({ page }) => {

--- a/tests/specs/functional/catalog/catalog.spec.ts
+++ b/tests/specs/functional/catalog/catalog.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import mockRepositories from 'tailor-seed/repositories.json' assert { type: 'json' };
+import mockRepositories from 'tailor-seed/repositories.json' with { type: 'json' };
 
 import { AddRepositoryDialog } from '../../../pom/catalog/AddRepository';
 import { Catalog } from '../../../pom/catalog/Catalog';
@@ -44,12 +44,14 @@ test('should be able to import a repository', async ({ page }) => {
 test('should be able to publish a repository from its card', async ({
   page,
 }) => {
-  const { data } = await SeedClient.seedTestRepository();
+  const {
+    data: { repository },
+  } = await SeedClient.seedTestRepository();
   await page.reload();
   const catalog = new Catalog(page);
   const card = new RepositoryCard(
     page,
-    catalog.findRepositoryCard(data.repository.name),
+    catalog.findRepositoryCard(repository.name),
   );
   await card.publish();
   await new Toast(page).expectPublished('Course');
@@ -59,12 +61,14 @@ test('should be able to publish a repository from its card', async ({
 test('should be able to clone a repository from its card', async ({
   page,
 }) => {
-  const { data } = await SeedClient.seedTestRepository();
+  const {
+    data: { repository },
+  } = await SeedClient.seedTestRepository();
   await page.reload();
   const catalog = new Catalog(page);
   const card = new RepositoryCard(
     page,
-    catalog.findRepositoryCard(data.repository.name),
+    catalog.findRepositoryCard(repository.name),
   );
   await card.runAction('Clone');
   const cloneDialog = new CloneDialog(page);
@@ -77,12 +81,14 @@ test('should be able to clone a repository from its card', async ({
 test('should be able to export a repository from its card', async ({
   page,
 }) => {
-  const { data } = await SeedClient.seedTestRepository();
+  const {
+    data: { repository },
+  } = await SeedClient.seedTestRepository();
   await page.reload();
   const catalog = new Catalog(page);
   const card = new RepositoryCard(
     page,
-    catalog.findRepositoryCard(data.repository.name),
+    catalog.findRepositoryCard(repository.name),
   );
   await card.runAction('Export');
   await new ExportDialog(page).download();
@@ -92,12 +98,14 @@ test('should be able to export a repository from its card', async ({
 test('should be able to delete a repository from its card', async ({
   page,
 }) => {
-  const { data } = await SeedClient.seedTestRepository();
+  const {
+    data: { repository },
+  } = await SeedClient.seedTestRepository();
   await page.reload();
   const catalog = new Catalog(page);
   const card = new RepositoryCard(
     page,
-    catalog.findRepositoryCard(data.repository.name),
+    catalog.findRepositoryCard(repository.name),
   );
   await card.delete();
   await new Toast(page).expectDeleted('Course');

--- a/tests/specs/functional/catalog/delete-repositories.spec.ts
+++ b/tests/specs/functional/catalog/delete-repositories.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import mockRepositories from 'tailor-seed/repositories.json' with { type: 'json' };
 
 import { Catalog } from '../../../pom/catalog/Catalog';
 import { ConfirmationDialog } from '../../../pom/common/ConfirmationDialog';
@@ -11,7 +12,9 @@ test.beforeEach(async ({ page }) => {
   const catalog = new Catalog(page);
   await expect(catalog.getRepositoryCards().first()).toBeVisible();
   await catalog.loadMore();
-  await expect(catalog.loadMoreBtn).not.toBeVisible();
+  await expect(catalog.getRepositoryCards()).toHaveCount(
+    mockRepositories.length,
+  );
 });
 
 test('should reveal card checkbox on hover', async ({ page }) => {
@@ -50,7 +53,7 @@ test('should show confirmation dialog before deleting', async ({ page }) => {
   const initialCount = await catalog.getRepositoryCards().count();
   await catalog.toggleRepository('Astronomy');
   await catalog.deleteSelectedBtn.click();
-  const dialog = new ConfirmationDialog(page, 'Delete repository');
+  const dialog = new ConfirmationDialog(page, 'Delete');
   await expect(dialog.el).toBeVisible();
   await dialog.close();
   await expect(dialog.el).not.toBeVisible();
@@ -66,9 +69,9 @@ test('should delete selected repositories after confirmation', async ({
   await catalog.toggleRepository('Physics');
   await expect(catalog.selectionCount).toContainText('2 selected');
   await catalog.deleteSelectedBtn.click();
-  const dialog = new ConfirmationDialog(page, 'Delete repositories');
+  const dialog = new ConfirmationDialog(page, 'Delete');
   await expect(dialog.el).toBeVisible();
-  await expect(dialog.el).toContainText('2 repositories');
+  await expect(dialog.el).toContainText(/delete 2 /i);
   await dialog.confirm();
   await expect(dialog.el).not.toBeVisible();
   await page.waitForLoadState('networkidle');

--- a/tests/specs/functional/collection/item-editing.spec.ts
+++ b/tests/specs/functional/collection/item-editing.spec.ts
@@ -1,8 +1,10 @@
-import { expect, test } from '@playwright/test';
-
-import SeedClient from '../../../api/SeedClient';
-import { addFirstItem, ENTITY, toCollection } from './helpers';
 import type { CollectionView } from '../../../pom/repository/collection/CollectionView';
+
+import { expect, test } from '@playwright/test';
+import { addFirstItem, ENTITY, toCollection } from './helpers';
+import { OutlineSidebar } from '../../../pom/repository/OutlineSidebar';
+import { Toast } from '../../../pom/common/Toast';
+import SeedClient from '../../../api/SeedClient';
 
 // Wide viewport so the editor's right sidebar docks beside the card instead of
 // overlaying it (its resize handle would otherwise intercept clicks).
@@ -49,11 +51,23 @@ test.describe('Collection - item metadata editing', () => {
     expect(await collection.titles()).toEqual(['Original']);
   });
 
-  test('deletes an item', async () => {
+  test('deletes an item', async ({ page }) => {
     await addFirstItem(collection, ENTITY.TAG, 'obsolete');
     await collection.entityFilter.select(ENTITY.TAG.label);
     const item = await collection.getItemByName('obsolete');
     await item.remove();
+    await new Toast(page).expectDeleted('Tag');
+    await expect(collection.emptyAlert).toBeVisible();
+  });
+
+  test('deletes an item from the sidebar', async ({ page }) => {
+    await addFirstItem(collection, ENTITY.AUTHOR, 'Tomás Rivera');
+    await collection.entityFilter.select(ENTITY.AUTHOR.label);
+    const item = await collection.getItemByName('Tomás Rivera');
+    await item.select();
+    const sidebar = new OutlineSidebar(page);
+    await sidebar.remove();
+    await new Toast(page).expectDeleted('Author');
     await expect(collection.emptyAlert).toBeVisible();
   });
 });

--- a/tests/specs/functional/common/user-profile.spec.ts
+++ b/tests/specs/functional/common/user-profile.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { faker } from '@faker-js/faker';
-import userSeed from 'tailor-seed/user.json' assert { type: 'json' };
+import userSeed from 'tailor-seed/user.json' with { type: 'json' };
 
 import {
   STRONG_TEST_PASSWORD,

--- a/tests/specs/functional/content-linking/activity-linking.spec.ts
+++ b/tests/specs/functional/content-linking/activity-linking.spec.ts
@@ -3,8 +3,8 @@ import { expect, test } from '@playwright/test';
 import {
   outlineLevel,
   outlineSeed,
-  toEmptyRepository,
   seedLinkedRepositories,
+  toEmptyRepository,
 } from '../../../helpers/seed';
 import { toEditorPage, toStructurePage } from '../../../helpers/navigation';
 import { ActivityOutline } from '../../../pom/repository/Outline';
@@ -12,21 +12,19 @@ import BaseClient from '../../../api/BaseClient';
 import { Editor } from '../../../pom/editor/Editor';
 import { EditorToolbar } from '../../../pom/editor/EditorToolbar';
 import { OutlineSidebar } from '../../../pom/repository/OutlineSidebar';
+import { Toast } from '../../../pom/common/Toast';
 import SeedClient from '../../../api/SeedClient';
 
 const api = new BaseClient('/api/repositories/');
-
-const seedSourceRepository = async () => {
-  const { data } = await SeedClient.seedTestRepository();
-  return data.repository;
-};
 
 test.beforeEach(async () => {
   await SeedClient.resetDatabase();
 });
 
 test('can link a leaf activity via options menu', async ({ page }) => {
-  const sourceRepo = await seedSourceRepository();
+  const {
+    data: { repository: sourceRepo },
+  } = await SeedClient.seedTestRepository();
   await toEmptyRepository(page);
   const outline = new ActivityOutline(page);
   const module = await outline.addFirstItem(outlineLevel.GROUP, 'Target Module');
@@ -35,6 +33,7 @@ test('can link a leaf activity via options menu', async ({ page }) => {
     sourceRepo.name,
     outlineSeed.primaryPage.title,
   );
+  await new Toast(page).expectLinked('Page');
   // Verify linked activity appears in outline with link icon
   await outline.toggleExpand();
   const linkedItem = await outline.getOutlineItemByName(
@@ -56,7 +55,9 @@ test('can link a leaf activity via options menu', async ({ page }) => {
 });
 
 test('can link a group activity via options menu', async ({ page }) => {
-  const sourceRepo = await seedSourceRepository();
+  const {
+    data: { repository: sourceRepo },
+  } = await SeedClient.seedTestRepository();
   await toEmptyRepository(page);
   const outline = new ActivityOutline(page);
   const module = await outline.addFirstItem(outlineLevel.GROUP, 'Target Module');
@@ -84,7 +85,9 @@ test('can link a group activity via options menu', async ({ page }) => {
 });
 
 test('can link a group activity below via options menu', async ({ page }) => {
-  const sourceRepo = await seedSourceRepository();
+  const {
+    data: { repository: sourceRepo },
+  } = await SeedClient.seedTestRepository();
   await toEmptyRepository(page);
   const outline = new ActivityOutline(page);
   const module = await outline.addFirstItem(outlineLevel.GROUP, 'Target Module');
@@ -109,7 +112,9 @@ test('can link a group activity below via options menu', async ({ page }) => {
 test('can link a leaf activity into a group via options menu', async ({
   page,
 }) => {
-  const sourceRepo = await seedSourceRepository();
+  const {
+    data: { repository: sourceRepo },
+  } = await SeedClient.seedTestRepository();
   await toEmptyRepository(page);
   const outline = new ActivityOutline(page);
   const module = await outline.addFirstItem(outlineLevel.GROUP, 'Target Module');
@@ -137,14 +142,15 @@ test('can link a leaf activity into a group via options menu', async ({
 });
 
 test('can link a leaf activity via toolbar menu', async ({ page }) => {
-  const sourceRepo = await seedSourceRepository();
+  const {
+    data: { repository: sourceRepo },
+  } = await SeedClient.seedTestRepository();
   await toEmptyRepository(page);
   const outline = new ActivityOutline(page);
   const linkDialog = await outline.linkFirst();
-  await linkDialog.selectAndLink(
-    sourceRepo.name,
-    outlineSeed.primaryPage.title,
-  );
+  await linkDialog.selectRepository(sourceRepo.name);
+  await linkDialog.selectActivity(outlineSeed.primaryPage.title);
+  await linkDialog.link();
   // Verify linked activity appears
   const linkedItem = await outline.getOutlineItemByName(
     outlineSeed.primaryPage.title,
@@ -161,7 +167,9 @@ test('can link a leaf activity via toolbar menu', async ({ page }) => {
 test('can navigate to linked parent from a nested linked child', async ({
   page,
 }) => {
-  const sourceRepo = await seedSourceRepository();
+  const {
+    data: { repository: sourceRepo },
+  } = await SeedClient.seedTestRepository();
   await toEmptyRepository(page);
   const outline = new ActivityOutline(page);
   const linkDialog = await outline.linkFirst();

--- a/tests/specs/functional/content-linking/activity-propagation.spec.ts
+++ b/tests/specs/functional/content-linking/activity-propagation.spec.ts
@@ -19,15 +19,12 @@ import SeedClient from '../../../api/SeedClient';
 
 const api = new BaseClient('/api/repositories/');
 
-const seedSourceRepository = async () => {
-  const { data } = await SeedClient.seedTestRepository();
-  return data.repository;
-};
-
 // Seed source pizza repo & create an empty target repo with "Target Module",
 // then link the source Module into it.
 const setupLinkedSourceModule = async (page: any) => {
-  const sourceRepo = await seedSourceRepository();
+  const {
+    data: { repository: sourceRepo },
+  } = await SeedClient.seedTestRepository();
   const targetRepo = await toEmptyRepository(page);
   const targetOutline = new ActivityOutline(page);
   const targetModule = await targetOutline.addFirstItem(
@@ -134,7 +131,9 @@ test('clone preserves linked content fields', async ({ page }) => {
 test('linking activity with children creates single revision', async ({
   page,
 }) => {
-  const sourceRepo = await seedSourceRepository();
+  const {
+    data: { repository: sourceRepo },
+  } = await SeedClient.seedTestRepository();
   const targetRepo = await toEmptyRepository(page);
   const outline = new ActivityOutline(page);
   // Link a group (which has child pages and content elements)

--- a/tests/specs/functional/content-linking/activity-propagation.spec.ts
+++ b/tests/specs/functional/content-linking/activity-propagation.spec.ts
@@ -194,7 +194,7 @@ test('export and reimport strips linked content fields', async ({ page }) => {
   const importName = `Reimported ${Date.now()}`;
   await addRepoDialog.nameInput.fill(importName);
   await addRepoDialog.descriptionInput.fill('reimport test');
-  await addRepoDialog.createRepositoryBtn.click();
+  await addRepoDialog.submitBtn.click();
   await page.waitForTimeout(5000);
   // Find the imported repository
   const { data: repos } = await api.get();

--- a/tests/specs/functional/repository/copy-activity.spec.ts
+++ b/tests/specs/functional/repository/copy-activity.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from '@playwright/test';
+
+import {
+  outlineLevel,
+  outlineSeed,
+  toEmptyRepository,
+} from '../../../helpers/seed';
+import { ActivityOutline } from '../../../pom/repository/Outline';
+import { Toast } from '../../../pom/common/Toast';
+import SeedClient from '../../../api/SeedClient';
+
+test.beforeEach(async () => {
+  await SeedClient.resetDatabase();
+});
+
+test('can copy an activity from another repository', async ({ page }) => {
+  const {
+    data: { repository: sourceRepo },
+  } = await SeedClient.seedTestRepository();
+  await toEmptyRepository(page);
+  const outline = new ActivityOutline(page);
+  await expect(outline.emptyCopyCard).toBeVisible();
+  const copyDialog = await outline.copyFirst();
+  // Copying at the root offers only root-level activity types (e.g. Module)
+  await copyDialog.selectAndCopy(sourceRepo.name, outlineSeed.group.title);
+  // Confirmation toast reflects the activity's type label (e.g. "Module")
+  await new Toast(page).expectCopied('Module');
+  // Copied activity appears in the outline as a plain (non-linked) duplicate
+  const copied = await outline.getOutlineItemByName(outlineSeed.group.title);
+  await expect(copied.linkIcon).not.toBeVisible();
+});
+
+test('can copy an activity via the outline toolbar', async ({ page }) => {
+  const {
+    data: { repository: sourceRepo },
+  } = await SeedClient.seedTestRepository();
+  await toEmptyRepository(page);
+  const outline = new ActivityOutline(page);
+  await outline.addFirstItem(outlineLevel.GROUP, 'Anchor Module');
+  const copyDialog = await outline.copyExisting();
+  await copyDialog.selectRepository(sourceRepo.name);
+  await copyDialog.selectActivity(outlineSeed.group.title);
+  await copyDialog.copy();
+  await new Toast(page).expectCopied('Module');
+  await outline.getOutlineItemByName(outlineSeed.group.title);
+});
+
+test.afterAll(async () => {
+  await SeedClient.resetDatabase();
+});

--- a/tests/specs/functional/repository/settings.spec.ts
+++ b/tests/specs/functional/repository/settings.spec.ts
@@ -1,9 +1,11 @@
 import { expect, test } from '@playwright/test';
 
 import { Catalog } from '../../../pom/catalog/Catalog';
+import { CloneDialog } from '../../../pom/repository/CloneDialog';
 import { GeneralSettings } from '../../../pom/repository/RepositorySettings';
-import SeedClient from '../../../api/SeedClient';
+import { Toast } from '../../../pom/common/Toast';
 import { toSeededRepositorySettings } from '../../../helpers/seed';
+import SeedClient from '../../../api/SeedClient';
 
 test.beforeEach(async ({ page }) => {
   await SeedClient.resetDatabase();
@@ -13,18 +15,24 @@ test.beforeEach(async ({ page }) => {
 test('should be able to delete the repository', async ({ page }) => {
   const settingsPage = new GeneralSettings(page);
   await settingsPage.rail.delete();
+  await new Toast(page).expectDeleted('Course');
   await expect(page.getByText('No repositories yet')).toBeVisible();
 });
 
 test('should be able to export the repository', async ({ page }) => {
   const settingsPage = new GeneralSettings(page);
   await settingsPage.rail.export();
+  await new Toast(page).expectExported('Course');
 });
 
 test('should be able to clone the repository', async ({ page }) => {
   const settingsPage = new GeneralSettings(page);
   const name = 'Cloned Repository';
-  await settingsPage.rail.clone(name);
+  await settingsPage.rail.runAction('Clone');
+  const cloneDialog = new CloneDialog(page);
+  await cloneDialog.expectTitle('Clone Course');
+  await cloneDialog.clone(name);
+  await new Toast(page).expectCloned('Course');
   await page.goto('/');
   await expect(page.getByText(name)).toBeVisible();
 });
@@ -32,6 +40,7 @@ test('should be able to clone the repository', async ({ page }) => {
 test('should be able to publish the repository', async ({ page }) => {
   const settingsPage = new GeneralSettings(page);
   await settingsPage.rail.publish();
+  await new Toast(page).expectPublished('Course');
   const repositoryName = await settingsPage.getName();
   await page.goto('/');
   const catalog = new Catalog(page);

--- a/tests/specs/functional/repository/structure.spec.ts
+++ b/tests/specs/functional/repository/structure.spec.ts
@@ -32,6 +32,7 @@ test(`should create a ${outlineLevel.GROUP} using bottom add button`, async ({
   await toEmptyRepository(page);
   const outline = new ActivityOutline(page);
   await outline.addFirstItem(outlineLevel.GROUP, `${outlineLevel.GROUP} 1`);
+  await new Toast(page).expectCreated(outlineLevel.GROUP);
 });
 
 test(`should be able to create a new sub ${outlineLevel.GROUP}`, async ({
@@ -43,6 +44,7 @@ test(`should be able to create a new sub ${outlineLevel.GROUP}`, async ({
   const parent = await outline.addFirstItem(outlineLevel.GROUP, parentName);
   const subLevelName = `Sub ${outlineLevel.GROUP}`;
   await parent.addInto(outlineLevel.GROUP, subLevelName);
+  await new Toast(page).expectCreated(outlineLevel.GROUP);
   await outline.getOutlineItemByName(subLevelName);
 });
 

--- a/tests/specs/functional/repository/structure.spec.ts
+++ b/tests/specs/functional/repository/structure.spec.ts
@@ -10,6 +10,7 @@ import { ActivityOutline } from '../../../pom/repository/Outline';
 import { Editor } from '../../../pom/editor/Editor';
 import { OutlineSidebar } from '../../../pom/repository/OutlineSidebar';
 import SeedClient from '../../../api/SeedClient';
+import { Toast } from '../../../pom/common/Toast';
 
 test.beforeEach(async () => {
   await SeedClient.resetDatabase();
@@ -76,6 +77,7 @@ test('should be able to delete the activity', async ({ page }) => {
   const outline = new ActivityOutline(page);
   const item = await outline.getOutlineItemByName(targetItem);
   await item.optionsMenu.remove();
+  await new Toast(page).expectDeleted('Module');
   const itemLocator = page.getByText(targetItem);
   await expect(itemLocator).not.toBeVisible();
   // Test persistence
@@ -94,9 +96,8 @@ test('should be able to edit the activity name', async ({ page }) => {
   const newName = `${targetItemName} - edited`;
   await sidebar.fillName(newName);
   await outline.getOutlineItemByName(newName);
-  // Test persistence
   await page.reload();
-  await expect(page.getByText(newName)).toBeVisible();
+  await outline.getOutlineItemByName(newName);
 });
 
 test('should be able to publish activity', async ({ page }) => {
@@ -109,6 +110,7 @@ test('should be able to publish activity', async ({ page }) => {
   const sidebar = new OutlineSidebar(page);
   await expect(sidebar.el).toContainText(/Not published/);
   await sidebar.publish();
+  await new Toast(page).expectPublished('Module');
   await expect(sidebar.el).toContainText(/Published on/);
 });
 

--- a/tests/specs/functional/repository/transfer-snapshot.spec.ts
+++ b/tests/specs/functional/repository/transfer-snapshot.spec.ts
@@ -11,6 +11,8 @@ import { faker } from '@faker-js/faker';
 import { ActivityOutline } from '../../../pom/repository/Outline';
 import { AddRepositoryDialog } from '../../../pom/catalog/AddRepository';
 import { Catalog } from '../../../pom/catalog/Catalog';
+import { NavigationRail } from '../../../pom/repository/NavigationRail';
+import { Toast } from '../../../pom/common/Toast';
 import SeedClient from '../../../api/SeedClient';
 
 const FIXTURE = './fixtures/test_schema_transfer.tgz';
@@ -28,11 +30,11 @@ test('imports & renders a repository whose schema is not in the registry',
     const description = faker.lorem.sentence(4);
     const dialog = new AddRepositoryDialog(page);
     await dialog.open();
-    await dialog.importRepository(name, description, FIXTURE);
-    await page.reload();
+    await dialog.submitImport(name, description, FIXTURE);
+    await new Toast(page).expectImportSucceeded();
     const catalog = new Catalog(page);
     const card = catalog.findRepositoryCard(name);
-    await expect(card).toBeVisible({ timeout: 10000 });
+    await expect(card).toBeVisible();
     await card.click();
     const outline = new ActivityOutline(page);
     await expect(outline.el).toBeVisible({ timeout: 15000 });
@@ -41,6 +43,31 @@ test('imports & renders a repository whose schema is not in the registry',
     await expect(page.getByText(ELEMENT_TEXT)).toBeVisible({ timeout: 10000 });
   },
 );
+
+test('clones a repository whose schema is embedded', async ({ page }) => {
+  const name = `Snapshot ${faker.lorem.word()} ${Date.now()}`;
+  const dialog = new AddRepositoryDialog(page);
+  await dialog.open();
+  await dialog.submitImport(name, faker.lorem.sentence(4), FIXTURE);
+  // Import toast doubles as the completion wait; the catalog refetches
+  await new Toast(page).expectImportSucceeded();
+  const catalog = new Catalog(page);
+  const card = catalog.findRepositoryCard(name);
+  await expect(card).toBeVisible();
+  await card.click();
+  const outline = new ActivityOutline(page);
+  await expect(outline.el).toBeVisible({ timeout: 15000 });
+  // Embedded schema resolved - the imported outline items render
+  await outline.getOutlineItemByName(ACTIVITY_NAME);
+  await new NavigationRail(page).clone('Cloned embedded repository');
+  await new Toast(page).expectCloned('Test Transfer');
+  await page.goto('/');
+  const clonedCard = catalog.findRepositoryCard('Cloned embedded repository');
+  await expect(clonedCard).toBeVisible();
+  await clonedCard.click();
+  await expect(outline.el).toBeVisible({ timeout: 15000 });
+  await outline.getOutlineItemByName(ACTIVITY_NAME);
+});
 
 test.afterAll(async () => {
   await SeedClient.resetDatabase();

--- a/tests/specs/functional/repository/workflow.spec.ts
+++ b/tests/specs/functional/repository/workflow.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/test';
 import { faker } from '@faker-js/faker';
 import { formatDate as format } from 'date-fns/format';
 import { sample } from 'lodash-es';
-import userSeed from 'tailor-seed/user.json' assert { type: 'json' };
+import userSeed from 'tailor-seed/user.json' with { type: 'json' };
 
 import {
   outlineSeed,


### PR DESCRIPTION
**Summary**

Every major repository and activity action now confirms itself with a toast; and both toasts and confirmation dialogs speak in the schema's own vocabulary ("Course", "Module", "Tag") instead of generic "repository"/"item".

**Changes**

- Confirmation toasts everywhere: creating/importing/cloning/exporting/publishing/deleting a repository, and creating/copying/linking/publishing/deleting outline activities and collection items all show a success toast; failures surface a red "We couldn't ..." toast instead of failing silently.
- Type-aware wording: dialogs and toasts name the concrete type via the new schemaApi.getLabel(repository) and singularized activity labels - e.g. "Delete Course?", "A new Page has been created". Bulk selections get correct grammar ("2 Pages have been linked") via a new describeSelection util; mixed-type selections fall back to "items".
- Dialog refinements:
  - Publish confirmations get a cloud-upload icon (icon is now configurable on ConfirmationDialog) and name the exact target.
  - Clone dialog prefills the original description and explains what's being cloned.
  - Copy/Link dialogs state the destination ("The selected content will be copied below "X""), and the Link dialog labels its source picker with all compatible source types (mapsTo).
  - Export dialog status restyled - plain text while preparing/ready, tonal alert only on error.
- Internal: NotificationSnackbar moved from the main layout to app.vue so toasts render globally; volatile timestamps hidden from Percy snapshots (data-percy="hide").

**Tests**

- Toast POM gains named helpers (expectCreated, expectCloned, expectDeletedMany, ...); specs across catalog, structure, settings, collections, content-linking, and copy-activity now assert the new toasts (which also replace arbitrary waits/reloads).
- New spec: cloning an imported repository whose schema is only embedded in the transfer snapshot.