### PR TITLE
Fix 400 on repository create/clone from whitespace-padded Name/Description

### DIFF
--- a/apps/frontend/app/components/common/RepositoryNameField.vue
+++ b/apps/frontend/app/components/common/RepositoryNameField.vue
@@ -90,7 +90,7 @@ const {
   value: nameInput,
   errors,
   validate,
-} = useField('name', string().required().min(2).max(250), {
+} = useField('name', string().trim().required().min(2).max(250), {
   initialValue: props.value,
 });
 

--- a/apps/frontend/app/components/repository/Settings/CloneModal.vue
+++ b/apps/frontend/app/components/repository/Settings/CloneModal.vue
@@ -114,8 +114,8 @@ const shareHint = computed(() => {
 
 const { defineField, errors, handleSubmit, resetForm, submitCount } = useForm({
   validationSchema: object({
-    name: string().required().min(2).max(NAME_MAX_LENGTH),
-    description: string().required().min(2).max(DESCRIPTION_MAX_LENGTH),
+    name: string().trim().required().min(2).max(NAME_MAX_LENGTH),
+    description: string().trim().required().min(2).max(DESCRIPTION_MAX_LENGTH),
   }),
   // The copy usually keeps the original description; the name must be new.
   initialValues: {

--- a/apps/frontend/app/plugins/vee-validate.ts
+++ b/apps/frontend/app/plugins/vee-validate.ts
@@ -1,13 +1,27 @@
-import { sentenceCase } from '@tailor-cms/utils';
+import { all, max as baseMax, min as baseMin } from '@vee-validate/rules';
 import { configure, defineRule } from 'vee-validate';
-import { all } from '@vee-validate/rules';
-import en from '@vee-validate/i18n/dist/locale/en.json';
 import { localize } from '@vee-validate/i18n';
+import { sentenceCase } from '@tailor-cms/utils';
+import en from '@vee-validate/i18n/dist/locale/en.json';
 
 export default defineNuxtPlugin(() => {
   Object.entries(all).forEach(([name, rule]) => {
     defineRule(name, rule);
   });
+
+  /**
+   * Trim strings before delegating to the built-in length validators.
+   */
+  const trimForLength = (value: unknown) =>
+    typeof value === 'string' ? value.trim() : value;
+
+  defineRule('min', (value: any, params: any) =>
+    baseMin(trimForLength(value), params),
+  );
+
+  defineRule('max', (value: any, params: any) =>
+    baseMax(trimForLength(value), params),
+  );
 
   defineRule('decimal', (value: any, [decimals = '*', separator = '.']) => {
     // null and undefined are valid values, should be handled by required rule


### PR DESCRIPTION
Fixes #705 (and the clone case in #528).

#### Problem
The backend trims text before length-checking (`z.string().trim().min(2)`), but the client validated the **raw** string. A value like `"a "` (1 char + trailing space) passed the client's `min:2`, got submitted, and the API rejected it with a raw **400**; no inline error.

#### Fix
Trim the value in the client validation layer so both sides measure the same string:

- **`plugins/vee-validate.ts`** - override `min`/`max` to trim string values before length-checking (aligns the rule with the server; the only user of this rule syntax is the Add Repository form).
- **`RepositoryNameField.vue`** - `.trim()` on the name yup schema (shared by create + clone).
- **`CloneModal.vue`** - `.trim()` on name + description yup schemas.