### PR TITLE
Assets Live upload progress with error/retry in file picker

### DIFF
--- a/apps/frontend/app/api/asset.js
+++ b/apps/frontend/app/api/asset.js
@@ -1,4 +1,4 @@
-import request from './request';
+import request, { uploadProgress } from './request';
 
 const urls = {
   base: (repositoryId) => `/repositories/${repositoryId}/assets`,
@@ -11,9 +11,10 @@ function getUrl(repositoryId, key) {
     .then((res) => res.data.url);
 }
 
-function upload(repositoryId, data) {
+function upload(repositoryId, data, { onProgress } = {}) {
   return request
     .post(urls.base(repositoryId), data, {
+      onUploadProgress: uploadProgress(onProgress),
       headers: {
         /*
         The default value of the Content-Type header is set to `application/json` inside

--- a/apps/frontend/app/api/repositoryAsset.js
+++ b/apps/frontend/app/api/repositoryAsset.js
@@ -1,5 +1,5 @@
 import { extractData } from './helpers';
-import request from './request';
+import request, { uploadProgress } from './request';
 
 const urls = {
   repository: (repositoryId) => `/repositories/${repositoryId}`,
@@ -37,11 +37,7 @@ function upload(repositoryId, files, { onProgress, folder } = {}) {
       // Unset default application/json so the browser sets multipart/form-data
       // with the correct boundary for FormData serialization
       headers: { 'Content-Type': undefined },
-      ...(onProgress && {
-        onUploadProgress: ({ loaded, total }) => {
-          if (total) onProgress(Math.round((loaded / total) * 100));
-        },
-      }),
+      onUploadProgress: uploadProgress(onProgress),
     })
     .then(extractData);
 }

--- a/apps/frontend/app/api/request.js
+++ b/apps/frontend/app/api/request.js
@@ -30,6 +30,17 @@ export function applyAuthInterceptor(target) {
   );
 }
 
+// Adapts axios upload-progress events into a 0..100 percent callback, the
+// single progress contract shared by every upload caller. Returns undefined
+// (which axios ignores) when no callback is given, so it can be passed through
+// unconditionally.
+export function uploadProgress(onProgress) {
+  if (!onProgress) return undefined;
+  return ({ loaded, total }) => {
+    if (total) onProgress(Math.round((loaded / total) * 100));
+  };
+}
+
 const config = {
   baseURL: '/api',
   withCredentials: true,

--- a/apps/frontend/app/composables/useStorageService.ts
+++ b/apps/frontend/app/composables/useStorageService.ts
@@ -7,15 +7,20 @@ const toFormData = (file: File) => {
   return form;
 };
 
+interface UploadOptions {
+  // Called with the completion percentage (0..100) as bytes are sent.
+  onProgress?: (percent: number) => void;
+}
+
 export const useStorageService = () => {
   const { $storageService: storage } = useNuxtApp() as any;
   const repositoryStore = useCurrentRepository();
 
-  const upload = (val: File | FormData) => {
+  const upload = (val: File | FormData, opts?: UploadOptions) => {
     // Accept both File and FormData for backward compatibility
     // (compiled CE packages pass FormData, future code can pass File directly)
     const form = val instanceof FormData ? val : toFormData(val);
-    return storage.upload(repositoryStore.repositoryId, form);
+    return storage.upload(repositoryStore.repositoryId, form, opts);
   };
 
   return {

--- a/packages/core-components/src/components/FileInput/PickerDialog/UploadProgress.vue
+++ b/packages/core-components/src/components/FileInput/PickerDialog/UploadProgress.vue
@@ -1,0 +1,56 @@
+<template>
+  <div class="upload-progress d-flex flex-column align-center justify-center">
+    <VIcon
+      class="mb-3"
+      color="primary"
+      icon="mdi-cloud-upload-outline"
+      size="52"
+    />
+    <div class="text-title-medium text-truncate w-100 text-center mb-4">
+      {{ isProcessing ? 'Processing' : 'Uploading' }} {{ fileName }}...
+    </div>
+    <VProgressLinear
+      :indeterminate="!isTransferring"
+      :model-value="progress ?? 0"
+      class="upload-progress-bar"
+      color="primary"
+      height="6"
+      rounded
+    />
+    <div v-if="isTransferring" class="text-body-small mt-2">{{ progress }}%</div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed } from 'vue';
+
+interface Props {
+  fileName?: string;
+  // Upload percent complete; null renders an indeterminate bar
+  progress?: number | null;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  fileName: '',
+  progress: null,
+});
+
+const isTransferring = computed(
+  () => props.progress !== null && props.progress < 100,
+);
+// Upload progress only tracks bytes sent, so it reaches 100% while the server
+// is still storing the asset — show a processing state instead of pinning the
+// bar at 100%.
+const isProcessing = computed(() => props.progress === 100);
+</script>
+
+<style lang="scss" scoped>
+.upload-progress {
+  // Match the dropzone footprint to avoid a dialog height jump
+  min-height: 16rem;
+}
+
+.upload-progress-bar {
+  max-width: 22rem;
+}
+</style>

--- a/packages/core-components/src/components/FileInput/PickerDialog/UploadTab.vue
+++ b/packages/core-components/src/components/FileInput/PickerDialog/UploadTab.vue
@@ -1,29 +1,62 @@
 <template>
   <div class="upload-tab-wrapper">
-    <VDefaultsProvider :defaults="{ VBtn: { color: 'primary' } }">
-      <VFileUpload
-        :filter-by-type="accept"
-        browse-text="Browse files"
-        class="upload-tab"
-        icon="mdi-cloud-upload-outline"
-        title="Drag & drop a file here"
-        @update:model-value="onSelect"
+    <UploadProgress v-if="isUploading" :file-name="fileName" :progress="progress" />
+    <template v-else>
+      <VAlert
+        v-if="errorMessage"
+        :text="errorMessage"
+        class="mb-4"
+        density="compact"
+        type="error"
+        variant="tonal"
       />
-    </VDefaultsProvider>
+      <VDefaultsProvider :defaults="{ VBtn: { color: 'primary' } }">
+        <VFileUpload
+          :filter-by-type="accept"
+          browse-text="Browse files"
+          class="upload-tab"
+          icon="mdi-cloud-upload-outline"
+          title="Drag & drop a file here"
+          @update:model-value="onSelect"
+        />
+      </VDefaultsProvider>
+    </template>
   </div>
 </template>
 
 <script lang="ts" setup>
-defineProps<{ accept?: string }>();
+import { ref } from 'vue';
+
+import UploadProgress from './UploadProgress.vue';
+
+interface Props {
+  accept?: string;
+  isUploading?: boolean;
+  // Upload percent complete; null renders an indeterminate bar
+  progress?: number | null;
+  errorMessage?: string;
+}
+
+withDefaults(defineProps<Props>(), {
+  accept: '',
+  isUploading: false,
+  progress: null,
+  errorMessage: '',
+});
 
 const emit = defineEmits<{
   select: [file: File];
 }>();
 
+// Name of the picked file; shown by the progress panel while uploading.
+const fileName = ref('');
+
 const onSelect = (files: File | File[] | null) => {
   if (!files) return;
   const file = Array.isArray(files) ? files[0] : files;
-  if (file) emit('select', file);
+  if (!file) return;
+  fileName.value = file.name;
+  emit('select', file);
 };
 </script>
 

--- a/packages/core-components/src/components/FileInput/PickerDialog/index.vue
+++ b/packages/core-components/src/components/FileInput/PickerDialog/index.vue
@@ -2,6 +2,7 @@
   <TailorDialog
     :model-value="modelValue"
     :header-icon="icon"
+    :persistent="isUploading"
     :theme="$vuetify.theme.global.name"
     :title="heading"
     width="800"
@@ -11,6 +12,7 @@
       <div class="px-5 pb-2">
         <VTabs
           v-model="activeTab"
+          :disabled="isUploading"
           selected-class="bg-surface-container-high"
           color=""
           grow
@@ -36,7 +38,13 @@
     <template #body>
       <VTabsWindow :key="sessionKey" v-model="activeTab">
         <VTabsWindowItem value="upload">
-          <UploadTab :accept="accept" @select="onFileSelect" />
+          <UploadTab
+            :accept="accept"
+            :error-message="uploadError"
+            :is-uploading="isUploading"
+            :progress="uploadProgress"
+            @select="emit('upload', $event)"
+          />
         </VTabsWindowItem>
         <VTabsWindowItem value="library" eager>
           <LibraryTab
@@ -52,7 +60,12 @@
     </template>
     <template #actions>
       <div class="px-2 pb-3">
-        <VBtn text="Cancel" variant="text" @click="onClose" />
+        <VBtn
+          :disabled="isUploading"
+          text="Cancel"
+          variant="text"
+          @click="onClose"
+        />
         <VBtn
           v-if="activeTab === 'library'"
           :disabled="!hasSelection"
@@ -96,6 +109,12 @@ interface Props {
   allowedExtensions?: string[];
   allowUrlSource?: boolean;
   multiple?: boolean;
+  // Upload in progress; keeps the dialog open and shows progress
+  isUploading?: boolean;
+  // Upload percent complete; null renders an indeterminate bar
+  uploadProgress?: number | null;
+  // Upload failure message shown on the Upload tab
+  uploadError?: string;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -105,6 +124,9 @@ const props = withDefaults(defineProps<Props>(), {
   allowedExtensions: () => [],
   allowUrlSource: false,
   multiple: false,
+  isUploading: false,
+  uploadProgress: null,
+  uploadError: '',
 });
 
 const emit = defineEmits<{
@@ -137,14 +159,8 @@ const selectLabel = computed(() => {
 });
 
 const onClose = () => {
+  if (props.isUploading) return;
   emit('update:modelValue', false);
-  activeTab.value = 'upload';
-  selectedAssets.value = props.multiple ? [] : null;
-};
-
-const onFileSelect = (file: File) => {
-  emit('upload', file);
-  onClose();
 };
 
 const toPayload = (asset: any) => ({
@@ -169,11 +185,15 @@ const onUrlSubmit = (data: { url: string; title?: string }) => {
   onClose();
 };
 
-// Fresh tab content on each dialog open
+// Fresh tab content, tab selection, and library selection on each
+// dialog open (close may be programmatic, so reset happens here)
 watch(
   () => props.modelValue,
   (open) => {
-    if (open) sessionKey.value++;
+    if (!open) return;
+    sessionKey.value++;
+    activeTab.value = 'upload';
+    selectedAssets.value = props.multiple ? [] : null;
   },
 );
 </script>

--- a/packages/core-components/src/components/FileInput/index.vue
+++ b/packages/core-components/src/components/FileInput/index.vue
@@ -36,6 +36,9 @@
     :allowed-extensions="allowedExtensions"
     :heading="dialogHeading"
     :icon="resolvedIcon"
+    :is-uploading="uploading"
+    :upload-error="uploadError"
+    :upload-progress="progress"
     @select="onSelect"
     @upload="onUploadFile"
   />
@@ -108,9 +111,20 @@ const emit = defineEmits<{
 }>();
 
 const storageService = inject<any>('$storageService');
-const { upload, downloadFile } = useUpload(emit as any);
+const {
+  upload,
+  uploading,
+  progress,
+  error: uploadError,
+  downloadFile,
+} = useUpload(emit as any);
 
 const dialogOpen = ref(false);
+
+// Discard a stale failure message from the previous session
+watch(dialogOpen, (isOpen) => {
+  if (isOpen) uploadError.value = '';
+});
 
 const dialogHeading = computed(() => {
   const base = props.placeholder || resolvedLabel.value;
@@ -179,7 +193,12 @@ watch(
   { immediate: true },
 );
 
-const onUploadFile = (file: File) => upload(file);
+// Dialog stays open showing progress; on failure it remains
+// open with the error so the user can retry
+const onUploadFile = async (file: File) => {
+  const payload = await upload(file);
+  if (payload) dialogOpen.value = false;
+};
 
 const onSelect = (payload: Record<string, any>) => emit('input', payload);
 

--- a/packages/core-components/src/composables/useUpload.ts
+++ b/packages/core-components/src/composables/useUpload.ts
@@ -1,9 +1,13 @@
+import pMinDelay from 'p-min-delay';
 import { inject, ref } from 'vue';
 
 import { useConfirmationDialog } from './useConfirmationDialog';
-import { useLoader } from './useLoader';
 
 type Emit = (event: 'upload' | 'delete', ...args: any[]) => void;
+
+// Floor the visible upload time so the progress panel doesn't flash on fast
+// (small-file / localhost) uploads.
+const MIN_LOADING_MS = 800;
 
 const download = (url: string, fileName: string) => {
   const anchor = document.createElement('a');
@@ -12,9 +16,12 @@ const download = (url: string, fileName: string) => {
 };
 
 export const useUpload = (emit: Emit) => {
+  const uploading = ref(false);
+  // Percent complete, or null when no progress has been reported yet (or the
+  // upload reports none at all); null renders as an indeterminate bar.
+  const progress = ref<number | null>(null);
   const error = ref('');
 
-  const { loading: uploading, loader } = useLoader();
   const storageService = inject<any>('$storageService');
   const showConfirmationDialog = useConfirmationDialog();
 
@@ -26,22 +33,36 @@ export const useUpload = (emit: Emit) => {
     });
   };
 
-  const upload = (file: File) => {
-    if (!file) return;
+  /**
+   * Uploads the file and emits the `upload` event on success.
+   * Resolves with the uploaded asset payload, or null on failure
+   */
+  const upload = async (file: File) => {
+    if (!file) return null;
+    uploading.value = true;
+    progress.value = null;
+    error.value = '';
     const form = new FormData();
     form.append('file', file, file.name);
-    return storageService
-      .upload(form)
-      .then((data: any) => {
-        const { name } = form.get('file') as File;
-        emit('upload', {
-          key: data.key,
-          name,
-          url: data.url,
-          publicUrl: data.publicUrl,
-        });
-      })
-      .catch(() => (error.value = 'An error has occurred!'));
+    try {
+      const uploadRequest: Promise<any> = storageService.upload(form, {
+        onProgress: (percent: number) => { progress.value = percent; },
+      });
+      const data = await pMinDelay(uploadRequest, MIN_LOADING_MS);
+      const payload = {
+        key: data.key,
+        name: file.name,
+        url: data.url,
+        publicUrl: data.publicUrl,
+      };
+      emit('upload', payload);
+      return payload;
+    } catch {
+      error.value = 'Upload failed. Please try again.';
+      return null;
+    } finally {
+      uploading.value = false;
+    }
   };
 
   const downloadFile = async (key: string, name: string) => {
@@ -50,10 +71,11 @@ export const useUpload = (emit: Emit) => {
   };
 
   return {
-    upload: loader(upload),
+    upload,
     downloadFile,
     deleteFile,
     uploading,
+    progress,
     error,
   };
 };

--- a/tests/helpers/deferred.ts
+++ b/tests/helpers/deferred.ts
@@ -1,0 +1,12 @@
+// Externally-resolvable promise: returns the promise together with its
+// resolve/reject. A lint-safe stand-in for `Promise.withResolvers()`, which
+// the repo's @typescript-eslint version rejects. Mirrors the backend Deferred.
+export function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}

--- a/tests/pom/common/FileInputPicker.ts
+++ b/tests/pom/common/FileInputPicker.ts
@@ -12,6 +12,8 @@ export class FileInputPicker {
 
   // Upload tab
   readonly uploadFileInput: Locator;
+  readonly uploadProgress: Locator;
+  readonly uploadError: Locator;
 
   // Library tab
   readonly librarySearch: Locator;
@@ -41,6 +43,8 @@ export class FileInputPicker {
     this.uploadFileInput = this.dialog.getByRole('button', {
       name: 'Browse files',
     });
+    this.uploadProgress = this.dialog.locator('.upload-progress');
+    this.uploadError = this.dialog.getByRole('alert');
 
     // Library tab
     this.librarySearch = this.dialog.getByPlaceholder('Search assets...');
@@ -88,14 +92,26 @@ export class FileInputPicker {
   }
 
   // Upload tab actions
-  async uploadFile(filePath: string) {
+  // Pick a file on the upload tab without waiting for the upload to
+  // finish (the dialog stays open showing progress until it does)
+  async selectUploadFile(filePath: string) {
     await this.switchToUpload();
     const [fileChooser] = await Promise.all([
       this.page.waitForEvent('filechooser'),
       this.uploadFileInput.click(),
     ]);
     await fileChooser.setFiles(filePath);
+  }
+
+  async uploadFile(filePath: string) {
+    await this.selectUploadFile(filePath);
     await this.waitForClose();
+  }
+
+  async expectUploading(fileName: string) {
+    await expect(this.uploadProgress).toBeVisible();
+    await expect(this.uploadProgress).toContainText(fileName);
+    await expect(this.cancelBtn).toBeDisabled();
   }
 
   // Library tab actions

--- a/tests/pom/common/FileInputPicker.ts
+++ b/tests/pom/common/FileInputPicker.ts
@@ -44,7 +44,7 @@ export class FileInputPicker {
       name: 'Browse files',
     });
     this.uploadProgress = this.dialog.locator('.upload-progress');
-    this.uploadError = this.dialog.getByRole('alert');
+    this.uploadError = this.dialog.locator('.v-alert[role="alert"]');
 
     // Library tab
     this.librarySearch = this.dialog.getByPlaceholder('Search assets...');

--- a/tests/specs/functional/assets/file-input.spec.ts
+++ b/tests/specs/functional/assets/file-input.spec.ts
@@ -5,9 +5,11 @@ import { AssetLibrary } from '../../../pom/repository/AssetLibrary';
 import { OutlineSidebar } from '../../../pom/repository/OutlineSidebar';
 import SeedClient from '../../../api/SeedClient';
 import { DOCUMENT, IMAGE } from '../../../fixtures/assets';
+import { deferred } from '../../../helpers/deferred';
 import { toFileMetaInput } from './helpers';
 
 const INPUT_PLACEHOLDER = 'Click to add a thumbnail image';
+const UPLOAD_ROUTE = '**/repositories/*/assets';
 
 test.describe('FileInput - upload tab', () => {
   test('can upload a file via the upload tab', async ({ page }) => {
@@ -19,6 +21,45 @@ test.describe('FileInput - upload tab', () => {
     await fileInput.expectFileSet(IMAGE.name);
     // Verify persistence
     await page.reload({ waitUntil: 'networkidle' });
+    await fileInput.expectFileSet(IMAGE.name);
+  });
+
+  test('keeps the dialog open with progress while uploading', async ({
+    page,
+  }) => {
+    await toFileMetaInput(page);
+    // Hold the upload request so the in-flight state is observable
+    const { promise: uploadGate, resolve: releaseUpload } = deferred();
+    await page.route(UPLOAD_ROUTE, async (route) => {
+      if (route.request().method() !== 'POST') return route.continue();
+      await uploadGate;
+      return route.continue();
+    });
+    const sidebar = new OutlineSidebar(page);
+    const fileInput = await sidebar.openFileMeta(INPUT_PLACEHOLDER);
+    await fileInput.picker.selectUploadFile(IMAGE.path);
+    await fileInput.picker.expectUploading(IMAGE.name);
+    releaseUpload();
+    await fileInput.picker.waitForClose();
+    await fileInput.expectFileSet(IMAGE.name);
+  });
+
+  test('shows an error and allows retry when the upload fails', async ({
+    page,
+  }) => {
+    await toFileMetaInput(page);
+    await page.route(UPLOAD_ROUTE, (route) => {
+      if (route.request().method() !== 'POST') return route.continue();
+      return route.fulfill({ status: 500, body: 'Upload error' });
+    });
+    const sidebar = new OutlineSidebar(page);
+    const fileInput = await sidebar.openFileMeta(INPUT_PLACEHOLDER);
+    await fileInput.picker.selectUploadFile(IMAGE.path);
+    await expect(fileInput.picker.uploadError).toContainText('Upload failed');
+    await expect(fileInput.picker.dialog).toBeVisible();
+    // Retry succeeds once the failure is lifted
+    await page.unroute(UPLOAD_ROUTE);
+    await fileInput.picker.uploadFile(IMAGE.path);
     await fileInput.expectFileSet(IMAGE.name);
   });
 


### PR DESCRIPTION
## Summary

Asset uploads now show live progress inside the file picker, with a graceful error/retry path, instead of freezing on an indeterminate spinner and silently closing on failure.

## Changes

- **File uploads show real progress.** Picking a file on the Upload tab keeps the dialog open and renders a live progress bar (0–100%) driven by the actual bytes sent, then a "Processing…" state while the server finishes storing the asset.
- **Uploads can fail gracefully.** A failed upload now shows an inline error on the Upload tab and leaves the dialog open so the user can retry, instead of silently closing. The dialog is persistent and its tabs/Cancel are disabled while an upload is in flight.
- **No progress flash on fast uploads.** A minimum visible duration (`pMinDelay`, 800 ms) keeps the progress panel from flickering on small-file / localhost uploads.

Internal:
- Extracted a single `uploadProgress()` helper in [request.js](apps/frontend/app/api/request.js) so every upload caller shares one axios-event → percent contract; removed the duplicated inline adapter in [repositoryAsset.js](apps/frontend/app/api/repositoryAsset.js) and wired it into [asset.js](apps/frontend/app/api/asset.js).
- `useUpload` now owns `uploading`/`progress`/`error` state and resolves with the asset payload (or `null` on failure) instead of relying on the generic loader.
- `useStorageService.upload` threads an `onProgress` option through to the storage service.
- Added a lint-safe `deferred()` test helper (stand-in for `Promise.withResolvers()`).

## Why / context

The upload flow gave no feedback on large files and closed silently on failure, so a failed or slow upload looked like a frozen dialog. This adds progress, a processing state, and an in-place retry — frontend-only.

## How to test

```
cd tests
pnpm playwright test specs/functional/assets/file-input.spec.ts --project=chrome-admin
```

Covers: dialog stays open with progress while uploading, and error + retry on a failed upload (500).

Manual:
- **Upload progress:** open any file meta input, drop a large image on the Upload tab — dialog stays open with a progress bar, then "Processing…", then closes.
- **Failure/retry:** block `POST /repositories/*/assets` (or kill the network) and upload — inline "Upload failed. Please try again." with the dialog still open; restore and retry succeeds.

## Screenshots / visual

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/edf3bb17-d705-4b63-9268-f3032c1dbb4c" />
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/190d21fb-d8e3-4d60-b431-70ae9de01de7" />

## Risk / rollback

Frontend-only; no migrations. Low risk — changes are scoped to the file picker and its upload composable.
