### PR TITLE
Editor: action-button placement, publish feedback, and user-group dialog

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailor-server",
-  "version": "9.0.0-beta.1",
+  "version": "10.0.0-beta.2",
   "codename": "Quilt",
   "author": "ExtensionEngine <info@extensionengine.com>",
   "type": "module",

--- a/apps/frontend/app/components/admin/UserGroupDialog.vue
+++ b/apps/frontend/app/components/admin/UserGroupDialog.vue
@@ -1,15 +1,24 @@
 <template>
   <TailorDialog
     v-model="isDialogVisible"
-    :title="`${isNewGroup ? 'Create' : 'Edit'} User Group`"
+    :title="`${isNewGroup ? 'Create a' : 'Edit'} user group`"
     header-icon="mdi-account-group"
     persistent
     @submit="submit"
   >
     <template #body>
-      <div class="d-flex justify-center mt-2 mb-7">
+      <div
+        v-if="isNewGroup"
+        class="text-body-small text-medium-emphasis mx-1 mb-2"
+      >
+        A user group is a shared workspace for a team. Everyone you add
+        works with the same content, and each member's role controls what
+        they can view and edit.
+      </div>
+      <div class="d-flex justify-center mt-6 mb-8">
         <GroupAvatar
           :img-url="logoUrlInput"
+          :size="150"
           @save="onAvatarSave"
           @delete="onAvatarSave('')"
         />

--- a/apps/frontend/app/components/common/Avatar/index.vue
+++ b/apps/frontend/app/components/common/Avatar/index.vue
@@ -2,14 +2,14 @@
   <div>
     <VSpeedDial content-class="flex-column" location="right" target="#avatar">
       <template #activator="{ props: activatorProps }">
-        <VAvatar id="avatar" size="180" color="surface-container-low" border="lg">
+        <VAvatar id="avatar" :size="size" color="surface-container-low" border="lg">
           <img v-if="imgUrl" :src="imgUrl" alt="Avatar" class="h-100 w-100" />
           <VIcon
             v-else
             :icon="placeholderIcon"
+            :size="placeholderIconSize"
             color="surface-container-highest"
             class="placeholder"
-            size="96"
           />
           <VSheet
             v-bind="(imgUrl && !isGravatar) ? activatorProps : {}"
@@ -18,7 +18,7 @@
             role="button"
             @click="!(imgUrl && !isGravatar) && triggerUpload()"
           >
-            <VIcon icon="mdi-camera" size="48" />
+            <VIcon icon="mdi-camera" :size="cameraIconSize" />
           </VSheet>
         </VAvatar>
       </template>
@@ -59,12 +59,18 @@ import { resizeAvatarImage } from './resize-image';
 export interface Props {
   imgUrl?: string;
   placeholderIcon?: string;
+  size?: number | string;
 }
 
 const props = withDefaults(defineProps<Props>(), {
   imgUrl: '',
   placeholderIcon: 'mdi-account-multiple',
+  size: 180,
 });
+
+// Keep the placeholder & camera icons proportional to the avatar circle.
+const placeholderIconSize = computed(() => Math.round(Number(props.size) * 0.53));
+const cameraIconSize = computed(() => Math.round(Number(props.size) * 0.27));
 
 const emit = defineEmits(['save', 'delete']);
 

--- a/apps/frontend/app/components/editor/Toolbar/ActivityActions.vue
+++ b/apps/frontend/app/components/editor/Toolbar/ActivityActions.vue
@@ -1,12 +1,21 @@
 <template>
   <div class="activity-actions d-flex align-center ga-1">
     <VBtn
-      v-for="{ active, title, icon, action, disabled, loading } in actions"
+      v-for="{
+        active,
+        title,
+        icon,
+        action,
+        disabled,
+        loading,
+        color,
+        iconSize,
+      } in actions"
       :key="title"
       v-tooltip:bottom="{ text: title, offset: 12 }"
       :active="active"
       :aria-label="title"
-      :color="active ? 'tertiary' : ''"
+      :color="color ?? (active ? 'tertiary' : '')"
       :disabled="disabled"
       :loading="loading"
       class="action-btn"
@@ -14,7 +23,7 @@
       icon
       @click.stop="action"
     >
-      <VIcon :icon="`mdi-${icon}`" size="small" />
+      <VIcon :icon="`mdi-${icon}`" :size="iconSize ?? 'small'" />
     </VBtn>
   </div>
 </template>
@@ -55,6 +64,8 @@ interface ToolbarAction {
   active?: boolean;
   disabled?: boolean;
   loading?: boolean;
+  color?: string;
+  iconSize?: string | number;
 }
 
 const actions = computed(() => {
@@ -99,7 +110,11 @@ const actions = computed(() => {
   if (!currentRepositoryStore.access.canPublish) return items;
   return items.concat({
     title: 'Publish',
-    icon: 'cloud-upload-outline',
+    icon: publishingUtils.showPublishSuccess.value
+      ? 'check-circle-outline'
+      : 'cloud-upload-outline',
+    color: publishingUtils.showPublishSuccess.value ? 'success' : undefined,
+    iconSize: publishingUtils.showPublishSuccess.value ? '1.7em' : undefined,
     loading: publishingUtils.isPublishing.value,
     action: () => confirmPublishing(),
   });

--- a/apps/frontend/app/composables/usePublishActivity.ts
+++ b/apps/frontend/app/composables/usePublishActivity.ts
@@ -1,13 +1,17 @@
 import type { StoreActivity } from '@/stores/activity';
 
 import { schema as schemaApi } from '@tailor-cms/config';
+import { refAutoReset } from '@vueuse/core';
 import Promise from 'bluebird';
+import pMinDelay from 'p-min-delay';
 import pluralize from 'pluralize-esm';
 
 import { api } from '@/api';
 import { useActivityStore } from '@/stores/activity';
 import { useCurrentRepository } from '@/stores/current-repository';
 
+const MIN_PUBLISH_MS = 1500;
+const PUBLISHED_FLASH_MS = 2000;
 const initialStatus = () => ({ progress: 0, message: '' });
 const prefix = (msg: string) => `Are you sure you want to publish ${msg}`;
 
@@ -22,6 +26,9 @@ export const usePublishActivity = (anchorActivity?: StoreActivity) => {
 
   const status = ref(initialStatus());
   const isPublishing = computed(() => status.value.progress > 0);
+  // Briefly confirm a successful publish once the
+  // spinner clears; refAutoReset flips it back after the delay.
+  const showPublishSuccess = refAutoReset(false, PUBLISHED_FLASH_MS);
 
   const getPublishMessage = (items: StoreActivity[]) => {
     const activityCount = items.length;
@@ -35,12 +42,20 @@ export const usePublishActivity = (anchorActivity?: StoreActivity) => {
   };
 
   const publish = (activities: StoreActivity[]) => {
-    return Promise.each(activities, (activity: StoreActivity, i: number) => {
-      const progress = (i + 1) / activities.length;
-      const message = `Publishing ${activity.data.name}`;
-      status.value = { progress, message };
-      return activityStore.publish(activity);
-    }).finally(() => (status.value = initialStatus()));
+    const task = Promise.each(
+      activities,
+      (activity: StoreActivity, i: number) => {
+        const progress = (i + 1) / activities.length;
+        const message = `Publishing ${activity.data.name}`;
+        status.value = { progress, message };
+        return activityStore.publish(activity);
+      },
+    );
+    // Keep the progress indicator visible long enough
+    // so the button spinner doesn't just flicker.
+    return pMinDelay(task, MIN_PUBLISH_MS).finally(
+      () => (status.value = initialStatus()),
+    );
   };
 
   const confirmPublishing = (activities: StoreActivity[]) => {
@@ -54,6 +69,7 @@ export const usePublishActivity = (anchorActivity?: StoreActivity) => {
         try {
           await publish(activities.filter((it) => !it.detached));
           notify(`The ${label} has been published`, { immediate: true });
+          showPublishSuccess.value = true;
         } catch {
           notify(`We couldn't publish the ${label}`, { color: 'error' });
         }
@@ -77,6 +93,7 @@ export const usePublishActivity = (anchorActivity?: StoreActivity) => {
           notify(`The ${repositoryTypeLabel} has been published`, {
             immediate: true,
           });
+          showPublishSuccess.value = true;
         } catch {
           notify(`We couldn't publish the ${repositoryTypeLabel}`, {
             color: 'error',
@@ -88,6 +105,7 @@ export const usePublishActivity = (anchorActivity?: StoreActivity) => {
 
   return {
     isPublishing,
+    showPublishSuccess,
     status,
     publish,
     confirmPublishing,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailor-cms",
-  "version": "10.0.0-beta.1",
+  "version": "10.0.0-beta.2",
   "codename": "Quilt",
   "description": "Next-gen Tailor",
   "license": "MIT",
@@ -14,6 +14,7 @@
     "lint": "eslint .",
     "seed": "cd ./apps/backend && pnpm db:seed",
     "e2e:functional": "cd tests && pnpm e2e:functional",
+  "seed:showcase": "cd tests && pnpm seed:showcase",
     "e2e:visual": "cd tests && pnpm e2e:visual",
     "e2e:a11y": "cd tests && pnpm e2e:a11y",
     "setup:dev": "pnpm i && node ./scripts/setup/index.js",

--- a/packages/core-components/src/components/ContentElement.vue
+++ b/packages/core-components/src/components/ContentElement.vue
@@ -3,6 +3,7 @@
   vuejs-accessibility/no-static-element-interactions -->
 <template>
   <div
+    ref="rootEl"
     :class="[
       element.diffChange,
       {
@@ -90,7 +91,10 @@
         <div class="pt-4 text-title-small">Component is not available!</div>
       </VSheet>
     </template>
-    <div v-if="!props.isDisabled" class="element-actions ga-1">
+    <div
+      v-if="!props.isDisabled"
+      :class="['element-actions', { comfortable: isComfortable }]"
+    >
       <div
         v-if="element.isLinkedCopy"
         :class="{ 'is-visible': isHighlighted || element.isLinkedCopy }"
@@ -115,7 +119,10 @@
       </div>
       <div
         v-if="showDiscussion"
-        :class="{ 'is-visible': isHighlighted || hasComments }"
+        :class="{
+          'is-visible': isHighlighted || hasComments,
+          'pinned-first': hasComments,
+        }"
       >
         <ElementLinkedDiscussion
           v-if="props.element.isLinkedCopy"
@@ -130,9 +137,6 @@
           :user="currentUser"
           @open="focus"
         />
-      </div>
-      <div v-if="showAI" :class="{ 'is-visible': isHighlighted }">
-        <ElementGeneration @generate="generateContent" />
       </div>
       <div :class="{ 'is-visible': isHighlighted }">
         <VBtn
@@ -170,6 +174,14 @@
 </template>
 
 <script lang="ts" setup>
+import type {
+  ContentElement,
+  ElementSourceInfo,
+} from '@tailor-cms/interfaces/content-element';
+import type { Activity } from '@tailor-cms/interfaces/activity';
+import type { ContentElementCategory } from '@tailor-cms/interfaces/schema';
+import type { Meta } from '@tailor-cms/interfaces/common';
+import type { User } from '@tailor-cms/interfaces/user';
 import {
   computed,
   inject,
@@ -178,23 +190,15 @@ import {
   provide,
   ref,
 } from 'vue';
-import type {
-  ContentElement,
-  ElementSourceInfo,
-} from '@tailor-cms/interfaces/content-element';
-import type { Activity } from '@tailor-cms/interfaces/activity';
+import { useResizeObserver } from '@vueuse/core';
 import { AiRequestType } from '@tailor-cms/interfaces/ai';
 import { cloneDeep } from 'lodash-es';
-import type { ContentElementCategory } from '@tailor-cms/interfaces/schema';
 import { getElementId } from '@tailor-cms/utils';
-import type { Meta } from '@tailor-cms/interfaces/common';
-import type { User } from '@tailor-cms/interfaces/user';
 
 import ActiveUsers from './ActiveUsers.vue';
 import CircularProgress from './CircularProgress.vue';
 import DiffChip from './DiffChip.vue';
 import ElementDiscussion from './ElementDiscussion.vue';
-import ElementGeneration from './ElementGeneration.vue';
 import ElementLinkedDiscussion from './ElementLinkedDiscussion.vue';
 import ElementLinkedIndicator from './ElementLinkedIndicator.vue';
 import ElementSourceUsages from './ElementSourceUsages.vue';
@@ -255,6 +259,7 @@ const isFocused = ref(false);
 const isSaving = ref(false);
 const currentUser = getCurrentUser?.();
 const activeUsers = ref<User[]>([]);
+const rootEl = ref<HTMLElement | null>(null);
 
 const id = computed(() => getElementId(props.element));
 const manifest = computed(() => ceRegistry.getByEntity(props.element));
@@ -264,9 +269,6 @@ const isHighlighted = computed(() => isFocused.value || props.isHovered);
 const hasComments = computed(() => !!props.element.comments?.length);
 const showDiff = computed(() => editorState?.showDiff.value);
 const isQuestion = computed(() => manifest.value?.isQuestion || false);
-const showAI = computed(
-  () => !props.element.embedded && !!doTheMagic && manifest.value?.ai,
-);
 
 // Linked element state
 const isElementEntryPoint = ref(true);
@@ -279,6 +281,17 @@ const sourceUsages = ref<ElementSourceInfo[] | null>(null);
 const showSourceUsages = computed(
   () => !props.element.isLinkedCopy && !props.element.embedded,
 );
+
+// The action column relaxes its vertical spacing once the host
+// element is tall enough.
+const COMFORTABLE_MIN_HEIGHT = 130;
+const isComfortable = ref(false);
+useResizeObserver(rootEl, ([entry]) => {
+  if (!entry) return;
+  const height = entry.borderBoxSize[0]?.blockSize ?? entry.contentRect.height;
+  const comfortable = height >= COMFORTABLE_MIN_HEIGHT;
+  if (comfortable !== isComfortable.value) isComfortable.value = comfortable;
+});
 
 const onSelect = (e: any) => {
   if (!props.isDisabled && !showDiff.value && !e.component) {
@@ -502,6 +515,7 @@ onMounted(() => {
 .element-actions {
   display: flex;
   flex-direction: column;
+  gap: 0.125rem;
   position: absolute;
   top: -0.0625rem;
   right: -2.5rem;
@@ -510,7 +524,8 @@ onMounted(() => {
   padding-left: 0.75rem;
 
   > * {
-    min-height: 1.75rem;
+    flex-shrink: 0;
+    min-height: 1.5rem;
     opacity: 0;
     transition: opacity 0.1s linear;
   }
@@ -518,6 +533,26 @@ onMounted(() => {
   > .is-visible {
     opacity: 1;
     transition: opacity 0.5s linear;
+  }
+
+  // With comments the icon stays visible while the row isn't hovered, so
+  // pin it to the top instead of leaving it below hidden hover-only actions.
+  > .pinned-first {
+    order: -1;
+  }
+
+  // More of vertical spacing when the host element has room; compact hosts
+  // keep the tight stack.
+  &.comfortable {
+    gap: 0.625rem;
+  }
+
+  :deep(.v-btn--icon.v-btn--size-x-small) {
+    --v-btn-height: 0.875rem;
+  }
+
+  :deep(.v-btn--size-x-small .v-icon) {
+    font-size: 1.25rem;
   }
 }
 

--- a/packages/core-components/src/components/ElementSourceUsages.vue
+++ b/packages/core-components/src/components/ElementSourceUsages.vue
@@ -8,12 +8,7 @@
     offset="4"
   >
     <template #activator="{ props: menuProps }">
-      <VBadge
-        :color="badgeColor"
-        :content="usages?.length ?? '?'"
-        offset-x="-2"
-        offset-y="-2"
-      >
+      <VBadge :color="badgeColor" :content="usages?.length ?? '?'">
         <VBtn
           v-tooltip:left="{
             text: 'Linked copies',
@@ -77,16 +72,16 @@ const props = withDefaults(defineProps<Props>(), {
 
 const emit = defineEmits<{
   'usages:fetch': [];
-  'usage:view': [usage: Usage];
+  'usage:view': [usage: ElementSourceInfo];
 }>();
 
 const menuOpen = ref(false);
 
-const badgeColor = computed(() => {
-  return props.usages?.length > 0 ? 'tertiary' : 'inverse-surface';
-});
+const badgeColor = computed(() =>
+  props.usages?.length ? 'tertiary' : 'inverse-surface',
+);
 
-const onViewUsage = (usage: Usage) => {
+const onViewUsage = (usage: ElementSourceInfo) => {
   emit('usage:view', usage);
   menuOpen.value = false;
 };
@@ -97,3 +92,14 @@ watch(menuOpen, (open) => {
   }
 });
 </script>
+
+<style lang="scss" scoped>
+// Compact count badge
+:deep(.v-badge__badge) {
+  height: 1rem;
+  min-width: 1rem;
+  padding: 0 0.1875rem;
+  font-size: 0.625rem;
+  transform: translate(0.5625rem, 0.125rem);
+}
+</style>


### PR DESCRIPTION
Summary

Editor UI polish across three areas:

- #744 Removed the per-element Generate content (AI) button from the action stack (question elements keep their own) and its dead wiring, then reworked the column: circular icon buttons, the comment action pinned to the top when an element has comments, the "linked copies" badge no longer overlapping the neighbour above it, and vertical spacing that only relaxes once the host element is tall enough. Also fixes uneven button spacing on short elements and two latent type errors in ElementSourceUsages.
- #734 The Publish button holds its spinner for a minimum duration so fast publishes don't flicker, then briefly flashes a success check before reverting to the cloud icon.
- User-group dialog. Clearer "Create a user group" title, a short line explaining what a group is for, a smaller (configurable) avatar, and more spacing.

Closes #744, #734

How to test

Manual (editor):
- Focus/hover content elements - short, tall, linked, and with comments - and confirm the action buttons are circular and evenly spaced, the comment sits on top when comments exist, and the linked-copies badge doesn't overlap the button above it.
- Publish an activity: spinner shows (min ~1.5s) → success check (~2s) → cloud icon; completion toast appears.
- Open Create a user group from the catalog workspace rail and from Admin → User groups.
