### PR TITLE
Remove auto-injected default "color" meta input

### DIFF
--- a/apps/backend/repository/repository.service.ts
+++ b/apps/backend/repository/repository.service.ts
@@ -15,7 +15,6 @@ import getVal from 'lodash/get.js';
 import groupBy from 'lodash/groupBy.js';
 import map from 'lodash/map.js';
 import pick from 'lodash/pick.js';
-import sample from 'lodash/sample.js';
 
 import type {
   BrokenActivityReference,
@@ -56,7 +55,6 @@ const {
 
 const logger = createLogger('repository:svc');
 
-const DEFAULT_COLORS = ['#689F38', '#FF5722', '#2196F3'];
 const lowercaseName = sequelize.fn('lower', sequelize.col('repository.name'));
 
 // Sequelize include builder for the user attached to a revision/membership
@@ -196,12 +194,11 @@ async function resolveFileMetaUrls(repositories: any[]) {
   return byRepo;
 }
 
-// Creates a repository seeded with schema-default meta + a sampled label
-// color, then optionally shares it with the supplied user groups.
+// Creates a repository seeded with schema-default meta, then optionally
+// shares it with the supplied user groups.
 export async function create(payload: CreateInput, user: User) {
   const defaultMeta = getVal(schemaApi.getSchema(payload.schema), 'defaultMeta', {});
   const data = {
-    color: sample(DEFAULT_COLORS),
     ...defaultMeta,
     ...stripServerManaged(payload.data),
   };

--- a/packages/tailor-config-parser/src/schema-processor.ts
+++ b/packages/tailor-config-parser/src/schema-processor.ts
@@ -8,15 +8,6 @@ import { find, isString, get, map, transform } from 'lodash-es';
 
 import validate from './schema-validation';
 
-const LABEL_COLORS = [
-  ['#F44336', '#E91E63'],
-  ['#9C27B0', '#673AB7'],
-  ['#3F51B5', '#2196F3'],
-  ['#03A9F4', '#00BCD4'],
-  ['#009688', '#4CAF50'],
-  ['#FF9800', '#FF5722'],
-];
-
 interface ProcessOptions {
   // Registered scoring rubric ids; when provided, schema
   // `feedback.rubrics` references are validated against them
@@ -49,17 +40,6 @@ export default (schemas: Schema[] = [], options: ProcessOptions = {}) => {
 
 function processRepositoryConfig(schema: Schema) {
   schema.meta = schema.meta || [];
-  const hasColorMeta = find(schema.meta, { key: 'color' });
-  if (!hasColorMeta) {
-    schema.meta.push({
-      type: 'COLOR',
-      key: 'color',
-      label: 'Label color',
-      colors: LABEL_COLORS,
-      hideOnCreate: true,
-      validate: {},
-    });
-  }
   normalizeFileMeta(schema.meta);
   schema.defaultMeta = getMetaDefaults(schema.meta);
 }


### PR DESCRIPTION
## Summary

Every repository schema had a `color` ("Label Color") meta input silently auto-injected by the schema processor, including its schema-authoring-only "Scheme" option. Removes the auto-injection so `color` is no longer added by default, and drops the now-dead random `data.color` seed in the repository create service.

Closes #721

## How to test

1. `pnpm dev`, open any repository (e.g. a Course-schema repo) → Settings → General.
2. Confirm the "Label Color" input no longer appears.
3. Create a new repository and confirm `repository.data` has no `color` key.