### PR TITLE
Allow clearing recent repositores, add min time spent to avoid poluting on misclicks

### DIFF
--- a/apps/frontend/CLAUDE.md
+++ b/apps/frontend/CLAUDE.md
@@ -41,8 +41,8 @@ Cross-cutting libs in `lib/`; the content-plugin registries live in
   single-purpose subcomponents rather than one growing file.
 - **Boolean props** use `is`/`has` prefixes (`isOpen`, `hasError`).
 - **Events** are namespaced `ns:action` (`save:element`, `delete:element`).
-- **Reuse** `packages/utils`, `@tailor-cms/common`, `core-components`, and
-  `lodash-es` instead of hand-rolling helpers.
+- **Reuse** `@vueuse/core`, `packages/utils`, `@tailor-cms/common`,
+  `core-components`, and `lodash-es` instead of hand-rolling helpers.
 - **Shallow nesting** - guard clauses / early returns, not deep if/else.
 
 ## Gotchas

--- a/apps/frontend/app/components/common/RepositorySelector.vue
+++ b/apps/frontend/app/components/common/RepositorySelector.vue
@@ -63,6 +63,17 @@
             <template #prepend>
               <VIcon :icon="repositoryIcon(item.id)" size="small" />
             </template>
+            <template v-if="isRemovableRecent(item.id)" #append>
+              <VBtn
+                :aria-label="`Remove ${item.name} from recents`"
+                class="remove-recent"
+                icon="mdi-close"
+                size="x-small"
+                variant="text"
+                density="comfortable"
+                @click.stop="removeRecent(item.id)"
+              />
+            </template>
           </VListItem>
         </VList>
         <div
@@ -87,11 +98,25 @@ const RECENT_LIMIT = 8;
 
 const props = defineProps<{ repository: Repository }>();
 
-const { search, items, recentItems, isLoading, hasLoaded, fetchRecent } =
-  useRepositorySwitcher();
+const {
+  search,
+  items,
+  recentItems,
+  isLoading,
+  hasLoaded,
+  fetchRecent,
+  removeRecent,
+} = useRepositorySwitcher();
 const recentRepositories = useRecentRepositories();
 
 const hasQuery = computed(() => !!search.value);
+
+// A row is a removable recent only in the default view: never the pinned
+// current repository, and never a search result.
+const isRemovableRecent = (id: number) =>
+  !hasQuery.value &&
+  id !== props.repository.id &&
+  recentRepositories.ids.value.includes(id);
 
 // The current repository is excluded; it renders from the prop, pinned first.
 const recentIds = computed(() => {
@@ -144,6 +169,24 @@ watch(isOpen, (open) => {
 </script>
 
 <style lang="scss" scoped>
+// Reveal the remove control on hover/focus only; keep it visible on touch
+// where there is no hover. Opacity (not v-if) so the row never reflows.
+.remove-recent {
+  opacity: 0;
+  transition: opacity 0.15s ease;
+
+  .v-list-item:hover &,
+  .v-list-item:focus-within & {
+    opacity: 1;
+  }
+}
+
+@media (hover: none) {
+  .remove-recent {
+    opacity: 1;
+  }
+}
+
 .repository-list :deep(.v-list-item-title) {
   white-space: normal;
   display: -webkit-box;

--- a/apps/frontend/app/composables/useRepositorySwitcher.ts
+++ b/apps/frontend/app/composables/useRepositorySwitcher.ts
@@ -1,5 +1,5 @@
 import type { Repository } from '@tailor-cms/interfaces/repository';
-import { keyBy, partition } from 'lodash-es';
+import { keyBy, partition, reject } from 'lodash-es';
 import { useDebounceFn } from '@vueuse/core';
 
 import { api } from '@/api';
@@ -54,6 +54,12 @@ export function useRepositorySwitcher() {
     }
   }
 
+  // Forget a repository from recents, dropping it from the visible list too.
+  function removeRecent(id: number) {
+    recentRepositories.remove([id]);
+    recentItems.value = reject(recentItems.value, { id });
+  }
+
   const debouncedFetch = useDebounceFn(fetch, 300);
   watch(search, (value) => {
     if (value) return debouncedFetch();
@@ -61,5 +67,13 @@ export function useRepositorySwitcher() {
     hasLoaded.value = false;
   });
 
-  return { search, items, recentItems, isLoading, hasLoaded, fetchRecent };
+  return {
+    search,
+    items,
+    recentItems,
+    isLoading,
+    hasLoaded,
+    fetchRecent,
+    removeRecent,
+  };
 }

--- a/apps/frontend/app/stores/current-repository.ts
+++ b/apps/frontend/app/stores/current-repository.ts
@@ -17,6 +17,7 @@ import {
   workflow as workflowConfig,
 } from '@tailor-cms/config';
 import { api } from '@/api';
+import { useTimeoutFn } from '@vueuse/core';
 import { useActivityStore } from './activity';
 import { useRepositoryStore } from './repository';
 import { filter } from 'lodash-es';
@@ -28,6 +29,10 @@ type Id = number | string;
 interface OutlineState {
   expanded: Map<string, boolean>;
 }
+
+// Only record a repository as "recent" after the user has stayed this long,
+// so accidental opens the user immediately bounces from never enter the list.
+const RECENT_MIN_VISIT_MS = 10_000;
 
 const getOutlineKey = (repositoryId: Id) =>
   `tailor-cms-outline:${repositoryId}`;
@@ -60,6 +65,12 @@ export const useCurrentRepository = defineStore('currentRepository', () => {
   });
 
   const repositoryId = ref<number | null>(null);
+
+  const { start: startRecentTimer, stop: stopRecentTimer } = useTimeoutFn(
+    () => repositoryId.value && recentRepositories.touch(repositoryId.value),
+    RECENT_MIN_VISIT_MS,
+    { immediate: false },
+  );
 
   const repository = computed(() => {
     return repositoryId.value ? Repository.findById(repositoryId.value) : null;
@@ -231,7 +242,7 @@ export const useCurrentRepository = defineStore('currentRepository', () => {
     await Activity.fetch(repoId, { outlineOnly: true });
     // Notify plugins about repository change (e.g., i18n initialization)
     if (repository.value) {
-      recentRepositories.touch(repoId);
+      startRecentTimer();
       $pluginRegistry.filter('repository:change', null, {
         schema: schema.value,
         repository: repository.value,
@@ -240,6 +251,7 @@ export const useCurrentRepository = defineStore('currentRepository', () => {
   };
 
   function $reset() {
+    stopRecentTimer();
     if (repositoryId.value) saveOutline(repositoryId.value, outlineState);
     repositoryId.value = null;
     outlineState.expanded.clear();

--- a/tests/helpers/seed.ts
+++ b/tests/helpers/seed.ts
@@ -8,6 +8,25 @@ import SeedClient from '../api/SeedClient';
 const REPOSITORY_API = new ApiClient('/api/repositories/');
 const USER_GROUP_API = new ApiClient('/api/user-group/');
 
+// localStorage key backing the repository switcher's recents (see
+// `useRecentRepositories`): repository id -> last-visit timestamp.
+const RECENT_REPOSITORIES_KEY = 'tailor-cms-recent-repositories';
+
+// Mirrors `RECENT_MIN_VISIT_MS` in the current-repository store: a visit only
+// becomes recent after the user stays this long. Advance an installed clock
+// past it to record a visit deterministically.
+export const RECENT_MIN_VISIT_MS = 10_000;
+
+// Seeds the recents store directly so the switcher lists these repositories as
+// recent, bypassing the minimum visit. Ids are ordered most-recent first.
+export const seedRecentRepositories = (page: Page, ids: number[]) => {
+  const store = Object.fromEntries(ids.map((id, i) => [id, ids.length - i]));
+  return page.addInitScript(
+    ([key, value]) => window.localStorage.setItem(key, value),
+    [RECENT_REPOSITORIES_KEY, JSON.stringify(store)] as [string, string],
+  );
+};
+
 // Creates a workspace (user group) via the REST API; returns the new group.
 export const createUserGroup = async (
   name: string,

--- a/tests/pom/common/AppBar.ts
+++ b/tests/pom/common/AppBar.ts
@@ -40,6 +40,11 @@ export class AppBar {
     await this.repositoryList.waitFor();
   }
 
+  async closeRepositorySwitcher() {
+    await this.page.keyboard.press('Escape');
+    await this.repositoryList.waitFor({ state: 'hidden' });
+  }
+
   repositoryItems() {
     return this.repositoryList.locator('.v-list-item');
   }
@@ -54,5 +59,15 @@ export class AppBar {
 
   switchToRepository(name: string) {
     return this.repositoryItem(name).click();
+  }
+
+  recentRemoveButton(name: string) {
+    return this.repositoryItem(name).getByRole('button', {
+      name: `Remove ${name} from recents`,
+    });
+  }
+
+  removeRecent(name: string) {
+    return this.recentRemoveButton(name).click();
   }
 }

--- a/tests/specs/functional/repository/repository-switcher.spec.ts
+++ b/tests/specs/functional/repository/repository-switcher.spec.ts
@@ -3,7 +3,12 @@ import { expect, test } from '@playwright/test';
 import ApiClient from '../../../api/ApiClient.ts';
 import { AppBar } from '../../../pom/common/AppBar.ts';
 import SeedClient from '../../../api/SeedClient.ts';
-import { createCleanRepository, toEmptyRepository } from '../../../helpers/seed.ts';
+import {
+  createCleanRepository,
+  RECENT_MIN_VISIT_MS,
+  seedRecentRepositories,
+  toEmptyRepository,
+} from '../../../helpers/seed.ts';
 
 const repositoryApi = new ApiClient('/api/repositories/');
 
@@ -40,7 +45,11 @@ test('searches for a repository and switches to it', async ({ page }) => {
 
 test('lists a previously visited repository as recent', async ({ page }) => {
   const recentName = 'Recent Repository';
+  // A visit only counts as recent past the minimum visit; advance the clock
+  // instead of waiting on wall-clock load time (what made this flake by env).
+  await page.clock.install();
   await toEmptyRepository(page, recentName);
+  await page.clock.fastForward(RECENT_MIN_VISIT_MS + 1_000);
   await toEmptyRepository(page, 'Current Repository');
   const appBar = new AppBar(page);
   await appBar.openRepositorySwitcher();
@@ -51,13 +60,49 @@ test('lists a previously visited repository as recent', async ({ page }) => {
 
 test('drops a deleted repository from recents', async ({ page }) => {
   const deletedName = 'Deleted Repository';
-  // Visited so it is recorded as recent, then deleted server-side.
-  const deleted = await toEmptyRepository(page, deletedName);
+  const deleted = await createCleanRepository(deletedName);
+  await seedRecentRepositories(page, [deleted.id]);
   await toEmptyRepository(page, 'Current Repository');
-  await repositoryApi.remove(deleted.id);
   const appBar = new AppBar(page);
+  // It lists as a genuine recent while the repository exists...
+  await appBar.openRepositorySwitcher();
+  await expect(appBar.repositoryItem(deletedName)).toBeVisible();
+  // ...and the switcher prunes it once the repository is gone server-side.
+  await repositoryApi.remove(deleted.id);
+  await appBar.closeRepositorySwitcher();
   await appBar.openRepositorySwitcher();
   await expect(appBar.repositoryItem(deletedName)).toHaveCount(0);
+});
+
+test('removes a repository from recents', async ({ page }) => {
+  const recentName = 'Recent Repository';
+  const keptName = 'Kept Repository';
+  const recent = await createCleanRepository(recentName);
+  const kept = await createCleanRepository(keptName);
+  await seedRecentRepositories(page, [recent.id, kept.id]);
+  await toEmptyRepository(page, 'Current Repository');
+  const appBar = new AppBar(page);
+  await appBar.openRepositorySwitcher();
+  await expect(appBar.repositoryItem(recentName)).toBeVisible();
+  await appBar.removeRecent(recentName);
+  await expect(appBar.repositoryItem(recentName)).toHaveCount(0);
+  // Other recents are untouched.
+  await expect(appBar.repositoryItem(keptName)).toBeVisible();
+});
+
+test('offers removal only for recents', async ({ page }) => {
+  const searchName = 'Searchable Repository';
+  // Created but never visited, so it surfaces only through search.
+  await createCleanRepository(searchName);
+  await toEmptyRepository(page, 'Current Repository');
+  const appBar = new AppBar(page);
+  await appBar.openRepositorySwitcher();
+  // The pinned current repository is not a removable recent.
+  await expect(appBar.recentRemoveButton('Current Repository')).toHaveCount(0);
+  // Neither are search results.
+  await appBar.searchRepositories(searchName);
+  await expect(appBar.repositoryItem(searchName)).toBeVisible();
+  await expect(appBar.recentRemoveButton(searchName)).toHaveCount(0);
 });
 
 test.afterAll(async () => {


### PR DESCRIPTION
## Summary
Gives users control over the navbar repository switcher's "recent" list: they can now remove an entry they no longer want, and repositories they only glance at no longer clutter the list in the first place.

## Changes
- **Remove a repository from recents.** Each recent row in the switcher now shows a close (✕) button that forgets just that repository, dropping it from both the visible list and the stored recents. It appears on hover/focus on pointer devices and stays visible on touch. The pinned current repository and live search results never show the control.
- **Ignore misclicks.** A repository is only recorded as "recent" after the user has stayed on it for 10s (`RECENT_MIN_VISIT_MS`). Opening a repo and immediately bouncing out no longer pushes it into the list. The dwell timer is cancelled when the current repository resets.

Internal: `useRepositorySwitcher` exposes a `removeRecent(id)` helper; the dwell timer uses `useTimeoutFn` from `@vueuse/core`.

## Why / context
The recent list is a fast path back to what you're actually working on, but it filled with noise — repositories opened by accident stuck around, and there was no way to prune them. Gating entry on a short dwell keeps accidental opens out, and a per-row remove handles the rest. The reveal-on-hover control uses opacity (not `v-if`) so rows never reflow as the cursor moves, and forces itself visible under `@media (hover: none)` since touch has no hover state.

## How to test
1. `pnpm dev`, sign in, open the navbar repository selector.
2. Hover a recent row → a ✕ appears; click it → the row disappears and stays gone after reopening the selector.
3. Confirm the ✕ never shows on the pinned current repository or on rows returned by typing a search query.
4. Open a repository and navigate away within ~10s → it should NOT appear in recents. Open another and stay >10s → it should appear.
5. On a touch device / device emulation, confirm the ✕ is always visible.

## Risk / rollback & follow-ups
Frontend-only, no migrations. Low risk. The 10s threshold is a hardcoded constant — worth revisiting if it feels too long/short in practice.