### PR TITLE
Fix exam objective refs, add empty-folder drop zones, bring back editor navigation tile for folder-only repos

### DIFF
--- a/apps/backend/openapi.json
+++ b/apps/backend/openapi.json
@@ -280,6 +280,10 @@
             "maximum": 9007199254740991,
             "description": "Referenced entity id."
           },
+          "entity": {
+            "description": "Model the pointer resolves against. Omit for same-entity refs (element -> element); set to `Activity` for an element -> activity ref such as an exam question's objective.",
+            "type": "string"
+          },
           "containerId": {
             "description": "Container activity id (for content-element refs).",
             "type": "integer",
@@ -550,10 +554,17 @@
               "type": "string"
             },
             "additionalProperties": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Relationship"
-              }
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Relationship"
+                  }
+                },
+                {
+                  "$ref": "#/components/schemas/Relationship"
+                }
+              ]
             },
             "description": "Cross-activity references (JSONB). Keyed by relationship type declared in the schema's `relationships` config for this activity type; values are arrays of `Relationship` pointers. Remapped on deep-clone via `mapClonedReferences`."
           },
@@ -2223,10 +2234,17 @@
               "type": "string"
             },
             "additionalProperties": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Relationship"
-              }
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Relationship"
+                  }
+                },
+                {
+                  "$ref": "#/components/schemas/Relationship"
+                }
+              ]
             },
             "description": "Cross-element references (JSONB). Keyed by the relationship types the schema declares for this element type via `elementMeta.relationships[]`; values are arrays of `Relationship` pointers. Remapped on deep-clone via `mapClonedReferences`."
           },
@@ -2375,10 +2393,17 @@
               "type": "string"
             },
             "additionalProperties": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Relationship"
-              }
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Relationship"
+                  }
+                },
+                {
+                  "$ref": "#/components/schemas/Relationship"
+                }
+              ]
             },
             "description": "Cross-element references (JSONB). Keyed by the relationship types the schema declares for this element type via `elementMeta.relationships[]`; values are arrays of `Relationship` pointers. Remapped on deep-clone via `mapClonedReferences`."
           },
@@ -3702,10 +3727,17 @@
                   "type": "string"
                 },
                 "additionalProperties": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Relationship"
-                  }
+                  "anyOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Relationship"
+                      }
+                    },
+                    {
+                      "$ref": "#/components/schemas/Relationship"
+                    }
+                  ]
                 },
                 "description": "Cross-activity references (JSONB). Keyed by relationship type declared in the schema's `relationships` config for this activity type; values are arrays of `Relationship` pointers. Remapped on deep-clone via `mapClonedReferences`."
               },
@@ -3929,10 +3961,17 @@
                   "type": "string"
                 },
                 "additionalProperties": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Relationship"
-                  }
+                  "anyOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Relationship"
+                      }
+                    },
+                    {
+                      "$ref": "#/components/schemas/Relationship"
+                    }
+                  ]
                 },
                 "description": "Cross-element references (JSONB). Keyed by the relationship types the schema declares for this element type via `elementMeta.relationships[]`; values are arrays of `Relationship` pointers. Remapped on deep-clone via `mapClonedReferences`."
               },
@@ -5844,10 +5883,17 @@
                       "type": "string"
                     },
                     "additionalProperties": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Relationship"
-                      }
+                      "anyOf": [
+                        {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/Relationship"
+                          }
+                        },
+                        {
+                          "$ref": "#/components/schemas/Relationship"
+                        }
+                      ]
                     },
                     "description": "Cross-activity references (JSONB). Keyed by relationship type declared in the schema's `relationships` config for this activity type; values are arrays of `Relationship` pointers. Remapped on deep-clone via `mapClonedReferences`."
                   }
@@ -6039,10 +6085,17 @@
                       "type": "string"
                     },
                     "additionalProperties": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Relationship"
-                      }
+                      "anyOf": [
+                        {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/Relationship"
+                          }
+                        },
+                        {
+                          "$ref": "#/components/schemas/Relationship"
+                        }
+                      ]
                     },
                     "description": "Cross-activity references (JSONB). Keyed by relationship type declared in the schema's `relationships` config for this activity type; values are arrays of `Relationship` pointers. Remapped on deep-clone via `mapClonedReferences`."
                   }
@@ -9450,10 +9503,17 @@
                       "type": "string"
                     },
                     "additionalProperties": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Relationship"
-                      }
+                      "anyOf": [
+                        {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/Relationship"
+                          }
+                        },
+                        {
+                          "$ref": "#/components/schemas/Relationship"
+                        }
+                      ]
                     },
                     "description": "Cross-element references (JSONB). Keyed by the relationship types the schema declares for this element type via `elementMeta.relationships[]`; values are arrays of `Relationship` pointers. Remapped on deep-clone via `mapClonedReferences`."
                   },
@@ -9812,10 +9872,17 @@
                       "type": "string"
                     },
                     "additionalProperties": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Relationship"
-                      }
+                      "anyOf": [
+                        {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/Relationship"
+                          }
+                        },
+                        {
+                          "$ref": "#/components/schemas/Relationship"
+                        }
+                      ]
                     },
                     "description": "Cross-element references (JSONB). Keyed by the relationship types the schema declares for this element type via `elementMeta.relationships[]`; values are arrays of `Relationship` pointers. Remapped on deep-clone via `mapClonedReferences`."
                   },

--- a/apps/backend/shared/request/schemas.ts
+++ b/apps/backend/shared/request/schemas.ts
@@ -1,6 +1,7 @@
 // Reusable Zod building blocks for action input / response schemas.
 // Centralised here so a "trimmed short text" rule reads identically across
 // actions and any tightening happens in one place.
+import { oneLine } from 'common-tags';
 import { z, type ZodType } from 'zod';
 
 // Standard `{ data: T }` response envelope. Non-`raw` actions wrap their
@@ -69,6 +70,16 @@ export const Int = () => z.number().int().positive();
 export const Relationship = z
   .object({
     id: Int().describe('Referenced entity id.'),
+    // Resolved by `detectMissingReferences`; without it the pointer is
+    // looked up in the owning entity's own table and pruned as missing.
+    entity: z
+      .string()
+      .optional()
+      .describe(oneLine`
+        Model the pointer resolves against. Omit for same-entity refs
+        (element -> element); set to \`Activity\` for an element -> activity
+        ref such as an exam question's objective.
+      `),
     containerId: Int()
       .optional()
       .describe('Container activity id (for content-element refs).'),
@@ -80,10 +91,14 @@ export const Relationship = z
   .meta({ id: 'Relationship' });
 
 // Cross-reference bag stored under `refs`. Keys are relationship type
-// names declared by the schema for the owning entity; values are arrays
-// of `Relationship` pointers.
+// names declared by the schema for the owning entity. Values are either a
+// list of `Relationship` pointers or, for single-valued relationships, one
+// bare pointer - both shapes are handled by `normalizeReferenceValue` and
+// `removeReference` in `shared/util/modelReference.js`.
 export const Refs = (desc = 'Cross-entity references (JSONB).') =>
-  z.record(z.string(), z.array(Relationship)).describe(desc);
+  z
+    .record(z.string(), z.union([z.array(Relationship), Relationship]))
+    .describe(desc);
 
 // Unsigned integer (>=0) for body/response fields where 0 is a
 // meaningful value: sizes (an empty file is 0 bytes), counts,

--- a/apps/frontend/app/components/editor/Sidebar/TailorTreeview/ItemGroup.vue
+++ b/apps/frontend/app/components/editor/Sidebar/TailorTreeview/ItemGroup.vue
@@ -3,7 +3,7 @@
     <template #activator="{ props: activatorProps, isOpen }">
       <ListItem
         v-bind="{ ...bindings, isOpen, activatorProps }"
-        :is-empty="!item.children.length"
+        :is-empty="isEmpty"
         is-group
         @edit="emit('edit', $event)"
       />
@@ -13,6 +13,8 @@
       :list="item.children"
       :move="repositoryStore.isValidDrop"
       animation="150"
+      class="drop-group"
+      filter=".drop-group__placeholder"
       group="activities"
       item-key="uid"
       @update="(data: SortableEvent) => reorder(data, item.children)"
@@ -24,6 +26,11 @@
           :item="element"
           @edit="emit('edit', $event)"
         />
+      </template>
+      <template #footer>
+        <div class="drop-group__placeholder text-body-small text-medium-emphasis">
+          No items yet
+        </div>
       </template>
     </Draggable>
   </VListGroup>
@@ -49,6 +56,8 @@ const emit = defineEmits(['edit']);
 const repositoryStore = useCurrentRepository();
 const reorder = useOutlineReorder();
 
+const isEmpty = computed(() => !props.item.children.length);
+
 const bindings = computed(() => {
   const { id, isEditable, title } = props.item;
   return {
@@ -59,3 +68,22 @@ const bindings = computed(() => {
   };
 });
 </script>
+
+<style lang="scss" scoped>
+.drop-group {
+  // The ghost is a real item, so a dragged item tracks drags in and out alike.
+  &:has(> [data-draggable]) .drop-group__placeholder {
+    display: none;
+  }
+
+  // Mirrors how Vuetify indents nested rows within `.v-list-group__items`.
+  &__placeholder {
+    display: flex;
+    align-items: center;
+    min-height: 2.25rem;
+    padding-inline-start: calc(16px + var(--indent-padding));
+    pointer-events: none;
+    user-select: none;
+  }
+}
+</style>

--- a/apps/frontend/app/components/repository/NavigationRail/index.vue
+++ b/apps/frontend/app/components/repository/NavigationRail/index.vue
@@ -67,6 +67,7 @@
 </template>
 
 <script lang="ts" setup>
+import type { Activity } from '@tailor-cms/interfaces/activity';
 import type { RepositoryAction } from '@/composables/useRepositoryActions';
 import type { RouteLocationRaw } from 'vue-router';
 
@@ -98,18 +99,17 @@ const activeUsers = computed(() =>
 );
 
 const lastEditorActivity = useLastEditorActivity();
-const { $schemaService } = useNuxtApp() as any;
 
-const isEditable = (activity: any) =>
-  !!activity && $schemaService.isEditable(activity.type);
+const isOpenable = (activity?: Activity): activity is Activity =>
+  !!activity && !activity.deletedAt;
 
 const editorActivityId = computed(() => {
-  const { repositoryId: id, outlineActivities } = repoStore;
-  if (!id) return null;
-  const saved = lastEditorActivity.get(id);
-  const activity = id ? outlineActivities.find((a: any) => a.id === id) : null;
-  if (isEditable(activity)) return saved;
-  return repoStore.outlineActivities.find(isEditable)?.id ?? null;
+  const { repositoryId, outlineActivities, rootActivities } = repoStore;
+  if (!repositoryId) return null;
+  const savedId = lastEditorActivity.get(repositoryId);
+  const saved = outlineActivities.find((it: any) => it.id === savedId);
+  if (isOpenable(saved)) return saved.id;
+  return rootActivities.find(isOpenable)?.id ?? null;
 });
 
 const selectedActivityQuery = computed(() => {

--- a/apps/frontend/app/components/repository/Outline/OutlineItem.vue
+++ b/apps/frontend/app/components/repository/Outline/OutlineItem.vue
@@ -87,17 +87,14 @@
       </template>
     </VHover>
     <VExpandTransition>
-      <div
-        v-if="!isSoftDeleted && isExpanded && hasSubtypes"
-        :class="{ 'mt-2': hasChildren }"
-      >
+      <div v-if="!isSoftDeleted && isExpanded && hasSubtypes" class="mt-2">
         <Draggable
           v-bind="{ handle: '.activity' }"
           :data-parent-id="activity.id"
           :list="children"
           :move="currentRepositoryStore.isValidDrop"
           animation="150"
-          class="d-flex flex-column ga-2"
+          class="drop-group d-flex flex-column ga-2"
           group="activities"
           item-key="uid"
           @update="(e: SortableEvent) => reorder(e, children)"
@@ -109,6 +106,18 @@
               :activity="element"
               :index="i + 1"
             />
+          </template>
+          <template #footer>
+            <VSheet
+              class="drop-group__placeholder"
+              color="transparent"
+              border="dotted md"
+            >
+              <div class="d-flex align-center opacity-60">
+                <VIcon icon="mdi-information-outline" size="small" start />
+                <span class="text-title-small">No items yet</span>
+              </div>
+            </VSheet>
           </template>
         </Draggable>
       </div>
@@ -240,5 +249,24 @@ const icon = computed(() => {
 
 .activity-wrapper .activity-wrapper {
   margin-left: 1.25rem;
+}
+
+.drop-group {
+  // The ghost is a real row, so a dragged row tracks drags in and out alike.
+  &:has(> [data-draggable]) .drop-group__placeholder {
+    display: none;
+  }
+
+  // Left margin aligns the zone with where nested rows would sit.
+  &__placeholder {
+    display: flex;
+    align-items: center;
+    min-height: 3.25rem;
+    margin-left: 1.25rem;
+    padding-left: 1rem;
+    border-radius: 0.25rem;
+    pointer-events: none;
+    user-select: none;
+  }
 }
 </style>

--- a/apps/frontend/app/components/repository/Search/CardPreview.vue
+++ b/apps/frontend/app/components/repository/Search/CardPreview.vue
@@ -13,7 +13,7 @@
         </VSheet>
         <VSheet
           v-else
-          class="preview-scale py-3"
+          class="preview-scale"
           color="surface"
           rounded="lg"
           border

--- a/apps/frontend/app/components/repository/Search/PreviewDialog.vue
+++ b/apps/frontend/app/components/repository/Search/PreviewDialog.vue
@@ -27,7 +27,7 @@
         <span class="text-body-medium mt-2">Preview unavailable</span>
       </VSheet>
       <div v-else ref="rootRef">
-        <VThemeProvider class="pa-6 rounded-lg" theme="light" with-background>
+        <VThemeProvider class="rounded-lg" theme="light" with-background>
           <ContentElementWrapper :element="element" is-disabled />
         </VThemeProvider>
       </div>

--- a/apps/frontend/app/plugins/global-components.ts
+++ b/apps/frontend/app/plugins/global-components.ts
@@ -12,5 +12,4 @@ export default defineNuxtPlugin((nuxt) => {
   nuxt.vueApp.component('TailorAssetInput', FileInputLegacy);
   nuxt.vueApp.component('TailorFileInput', FileInput);
   nuxt.vueApp.component('TailorElementPlaceholder', ElementPlaceholder);
-  nuxt.vueApp.component('TailorContentElement', ContentElement);
 });

--- a/packages/core-components/src/components/AddElement/index.vue
+++ b/packages/core-components/src/components/AddElement/index.vue
@@ -205,6 +205,7 @@ const addLinkedElements = async (elements: any[]) => {
       type: el.type,
       data: { ...el.data, width: processedWidth.value },
       meta: el.meta,
+      refs: {},
       position: positions[index],
       activityId: props.activity!.id,
       isLinkedCopy: true,
@@ -234,7 +235,8 @@ const generateContent = async (element: ContentElement) => {
 const buildElement = async (el: any) => {
   const { position, data = {}, initState = () => ({}), config } = el;
   const element = {
-    ...pick(el, ['type', 'refs', 'contentId']),
+    ...pick(el, ['type', 'contentId']),
+    refs: el.refs ?? {},
     data: { ...initState(), ...data, width: processedWidth.value },
     position,
   };

--- a/packages/core-components/src/components/AssessmentItem.vue
+++ b/packages/core-components/src/components/AssessmentItem.vue
@@ -1,7 +1,7 @@
 <template>
   <VHover v-slot="{ isHovering, props: hoverProps }">
     <ContentElementWrapper
-      v-bind="hoverProps"
+      v-bind="{ ...$attrs, ...hoverProps }"
       :element="element"
       :embed-element-config="embedElementConfig"
       :expanded="expanded"
@@ -25,6 +25,8 @@ import type { ContentElement } from '@tailor-cms/interfaces/content-element';
 import type { ContentElementCategory } from '@tailor-cms/interfaces/schema';
 
 import ContentElementWrapper from './ContentElement/index.vue';
+
+defineOptions({ inheritAttrs: false });
 
 interface Props {
   element: ContentElement;

--- a/packages/core-components/src/components/TailorDialog.vue
+++ b/packages/core-components/src/components/TailorDialog.vue
@@ -17,6 +17,16 @@
               <VIcon :icon="headerIcon" :color="color" />
             </template>
             <VCardTitle class="dialog-title">{{ title }}</VCardTitle>
+            <template v-if="closeable" #append>
+              <VBtn
+                data-testid="tailorDialogClose"
+                density="comfortable"
+                icon="mdi-close"
+                title="Close"
+                variant="text"
+                @click="defaultProps.isActive.value = false"
+              />
+            </template>
           </VCardItem>
           <div v-if="$slots.subheader" class="dialog-subheader">
             <slot name="subheader"></slot>
@@ -51,6 +61,7 @@ export interface Props {
   width?: number | string;
   dataTestid?: string;
   color?: string;
+  closeable?: boolean;
 }
 
 withDefaults(defineProps<Props>(), {
@@ -59,6 +70,7 @@ withDefaults(defineProps<Props>(), {
   color: 'primary',
   width: 500,
   dataTestid: 'tailorDialog',
+  closeable: false,
 });
 
 const emit = defineEmits(['open', 'close', 'submit']);

--- a/packages/core-extensions/content-containers/exam-edit/src/edit/Assessment.vue
+++ b/packages/core-extensions/content-containers/exam-edit/src/edit/Assessment.vue
@@ -11,7 +11,7 @@
     @selected="expanded = !expanded"
   >
     <template #header>
-      <div v-if="objectives.length || objectiveId" class="d-flex px-6 py-4">
+      <div v-if="objectives.length || objectiveId" class="d-flex py-2">
         <VRow justify="end" no-gutters class="mt-2">
           <VCol cols="5">
             <VAutocomplete
@@ -19,6 +19,7 @@
               :disabled="isDisabled"
               :items="objectives"
               :placeholder="objectiveLabel"
+              density="comfortable"
               item-title="data.name"
               item-value="id"
               variant="outlined"

--- a/packages/core-extensions/content-containers/exam-edit/src/edit/Assessment.vue
+++ b/packages/core-extensions/content-containers/exam-edit/src/edit/Assessment.vue
@@ -64,7 +64,7 @@ const save = (assessment: Record<string, any>) => {
     const objective = objectiveId.value
       ? { id: objectiveId.value, entity: objectiveEntity }
       : undefined;
-    assessment.refs = { ...assessment.refs, objective };
+    assessment.refs.objective = objective;
   }
   emit('save', assessment);
 };

--- a/packages/core-extensions/content-containers/exam-edit/src/edit/Assessment.vue
+++ b/packages/core-extensions/content-containers/exam-edit/src/edit/Assessment.vue
@@ -63,7 +63,7 @@ const save = (assessment: Record<string, any>) => {
     const objective = objectiveId.value
       ? { id: objectiveId.value, entity: objectiveEntity }
       : undefined;
-    assessment.refs.objective = objective;
+    assessment.refs = { ...assessment.refs, objective };
   }
   emit('save', assessment);
 };

--- a/packages/core-extensions/content-containers/exam-edit/src/edit/AssessmentGroup.vue
+++ b/packages/core-extensions/content-containers/exam-edit/src/edit/AssessmentGroup.vue
@@ -1,5 +1,5 @@
 <template>
-  <VExpansionPanel :value="group.uid" class="assessment-group">
+  <VExpansionPanel :value="group.uid" class="assessment-group elevation-1">
     <VHover v-slot="{ isHovering, props: hoverProps }">
       <VExpansionPanelTitle v-bind="hoverProps" min-height="64" static>
         <div class="text-body-large font-weight-bold">

--- a/packages/core-extensions/content-containers/exam-edit/src/edit/GroupIntroduction.vue
+++ b/packages/core-extensions/content-containers/exam-edit/src/edit/GroupIntroduction.vue
@@ -15,7 +15,7 @@
       :elements="elements"
       :is-disabled="isDisabled"
       :supported-element-config="introductionElementConfig"
-      class="pa-4"
+      class="pa-0"
       layout
       @add="$emit('save:element', $event)"
       @update="$emit('reorder:element', $event)"

--- a/packages/core-extensions/content-containers/exam-edit/src/edit/index.vue
+++ b/packages/core-extensions/content-containers/exam-edit/src/edit/index.vue
@@ -1,6 +1,7 @@
 <template>
-  <VCard color="surface-container" elevation="0" rounded="lg" border>
+  <VCard color="surface-container" elevation="0" rounded="lg">
     <VCard
+      :ripple="false"
       color="transparent"
       elevation="0"
       rounded="0"

--- a/packages/core-extensions/content-containers/exam-edit/src/edit/index.vue
+++ b/packages/core-extensions/content-containers/exam-edit/src/edit/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <VCard color="surface-sunken" elevation="0" rounded="lg">
+  <VCard color="surface-container" elevation="0" rounded="lg" border>
     <VCard
       color="transparent"
       elevation="0"

--- a/packages/core-extensions/content-containers/page/src/edit/index.vue
+++ b/packages/core-extensions/content-containers/page/src/edit/index.vue
@@ -110,10 +110,7 @@
 </template>
 
 <script lang="ts" setup>
-import type {
-  ContentElement,
-  Relationship,
-} from '@tailor-cms/interfaces/content-element';
+import type { ContentElement } from '@tailor-cms/interfaces/content-element';
 import type { Activity } from '@tailor-cms/interfaces/activity';
 import type { AiInput } from '@tailor-cms/interfaces/ai';
 import type { ContentElementCategory } from '@tailor-cms/interfaces/schema';
@@ -126,7 +123,7 @@ import {
   InlineActivator,
 } from '@tailor-cms/core-components';
 import { AiRequestType, AiResponseSchema } from '@tailor-cms/interfaces/ai';
-import { filter, reduce, sortBy } from 'lodash-es';
+import { castArray, filter, reduce, sortBy } from 'lodash-es';
 import { computed, inject, ref } from 'vue';
 
 interface Props {
@@ -225,11 +222,11 @@ const saveElement = (element: ContentElement, key: string, data: any) => {
   });
 };
 
-const getRefElements = (refs: Record<string, Relationship[]>) => {
+const getRefElements = (refs: ContentElement['refs']) => {
   return reduce(
     refs,
     (acc: any, it, key: string) => {
-      const elements = it.map(({ uid }) => props.elements[uid]);
+      const elements = castArray(it).map(({ uid }) => props.elements[uid]);
       acc[key] = elements.filter(Boolean) as ContentElement[];
       return acc;
     },

--- a/packages/tailor-interfaces/content-element.ts
+++ b/packages/tailor-interfaces/content-element.ts
@@ -14,6 +14,8 @@ export interface Relationship {
   uid?: string;
   containerId?: number;
   outlineId?: number;
+  /** Model the pointer resolves against; omitted for same-entity refs. */
+  entity?: string;
 }
 
 export interface RelationshipType extends ElementRelationship {
@@ -48,9 +50,11 @@ export interface ContentElement {
   /**
    * Cross-element references keyed by the relationship types the schema
    * declares for this element type via `elementMeta.relationships[]`.
-   * Values are arrays of pointers (see `Relationship`).
+   * Values are arrays of pointers (see `Relationship`); single-valued
+   * relationships store one bare pointer instead (e.g. an exam question's
+   * `objective`, which points at an Activity).
    */
-  refs: Record<string, Relationship[]>;
+  refs: Record<string, Relationship[] | Relationship>;
   /** Parent is soft-deleted */
   detached: boolean;
   /** Whether this element is an active linked copy */


### PR DESCRIPTION
## Summary

Fixes exam question objectives being silently dropped, makes empty folders a visible drop target in both outline views, and clears a batch of editor/exam polish items that had accumulated.

## Changes

- **Exam question objectives persist again.** An objective is a single pointer at an `Activity`, but the shared `Relationship`/`Refs` request schemas only accepted arrays of same-entity pointers - so Zod stripped `entity` and the bare-object shape, and `detectMissingReferences` then looked the id up in the *owning* entity's table and pruned the ref as missing.
- **Empty folders show a "No items yet" drop zone** in the outline and in the editor sidebar treeview.
- **The editor opens for repositories that contain only folders.** The nav rail entry previously required an *editable* activity type and, separately, looked up the saved activity by `repositoryId` instead of the saved id - so the check never matched. It now resolves the saved activity properly and falls back to the first non-deleted root activity.
- **`TailorDialog` gained a `closeable` prop**
- **Search preview polish** - dropped the extra padding in the card preview and the preview dialog's theme provider so previews render at true scale.