### PR TITLE
Decode HTML in element preview text

### DIFF
--- a/apps/frontend/app/components/repository/Search/SearchSnippet.vue
+++ b/apps/frontend/app/components/repository/Search/SearchSnippet.vue
@@ -4,14 +4,17 @@
 </template>
 
 <script lang="ts" setup>
+import { decode } from 'html-entities';
 import { escape } from 'lodash-es';
 
 const props = defineProps<{ snippet: string }>();
 
+// The BE strips tags off the stored rich text but leaves its entities
+// encoded, so they are decoded before escaping;
 // The BE wraps matches in `⟪`/`⟫` markers; they are swapped for real
 // markup only after escaping, so element content can't inject HTML.
 const rendered = computed(() =>
-  escape(props.snippet)
+  escape(decode(props.snippet))
     .replaceAll('⟪', '<mark>')
     .replaceAll('⟫', '</mark>'),
 );

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -52,6 +52,7 @@
     "debug": "^4.4.3",
     "events": "^3.3.0",
     "hashids": "^2.3.0",
+    "html-entities": "^2.6.0",
     "humanize-string": "^3.1.0",
     "lodash-es": "^4.18.1",
     "marked": "^18.0.7",

--- a/packages/core-components/src/components/ContentElement/index.vue
+++ b/packages/core-components/src/components/ContentElement/index.vue
@@ -172,6 +172,7 @@ import { isEqual } from 'lodash-es';
 import {
   getElementId,
   getQuestionPromptPreview,
+  htmlToText,
   titleCase,
 } from '@tailor-cms/utils';
 
@@ -287,11 +288,7 @@ const preview = computed(() => {
   if (isQuestion.value) return questionPreview.value;
   const content = props.element.data?.content;
   if (typeof content !== 'string') return '';
-  return content
-    .replace(/<[^>]+>/g, ' ')
-    .replace(/&nbsp;/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim();
+  return htmlToText(content);
 });
 
 const questionPreview = computed(() => {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@paralleldrive/cuid2": "^3.3.0",
+    "html-entities": "^2.6.0",
     "lodash-es": "^4.18.1",
     "uuid": "^14.0.1"
   },

--- a/packages/utils/src/html.ts
+++ b/packages/utils/src/html.ts
@@ -1,0 +1,18 @@
+import { decode } from 'html-entities';
+
+const tagRegex = /<[^>]+>/g;
+
+/**
+ * Flattens an HTML string into single-line plain text: drops tags, decodes
+ * the entities they leave behind, then collapses whitespace. Rich text is
+ * stored as HTML, so a literal `&` lives in the data as `&amp;` and has to
+ * be decoded before it can be rendered as text.
+ *
+ * Tags are stripped before decoding on purpose. Decoding first would turn an
+ * escaped, authored `&lt;b&gt;` into a real `<b>`, which the tag pass would
+ * then delete along with the text the author actually wrote.
+ */
+export const htmlToText = (html: string) =>
+  decode(html.replace(tagRegex, ' '))
+    .replace(/\s+/g, ' ')
+    .trim();

--- a/packages/utils/src/html.ts
+++ b/packages/utils/src/html.ts
@@ -1,6 +1,6 @@
 import { decode } from 'html-entities';
 
-const tagRegex = /<[^>]+>/g;
+const tagRegex = /<[^<>]+>/g;
 
 /**
  * Flattens an HTML string into single-line plain text: drops tags, decodes
@@ -11,6 +11,9 @@ const tagRegex = /<[^>]+>/g;
  * Tags are stripped before decoding on purpose. Decoding first would turn an
  * escaped, authored `&lt;b&gt;` into a real `<b>`, which the tag pass would
  * then delete along with the text the author actually wrote.
+ *
+ * The tag pattern skips `<` as well as `>` so a tag never spans another
+ * `<`; otherwise text full of unclosed `<` gets rescanned from each one.
  */
 export const htmlToText = (html: string) =>
   decode(html.replace(tagRegex, ' '))

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,18 +1,20 @@
 import type { ContentElement } from '@tailor-cms/interfaces/content-element';
+
 import { filter, kebabCase, map } from 'lodash-es';
+import { htmlToText } from './html';
 
 export * from './access';
 export * from './calculatePosition';
 export * as activity from './activity';
-export { default as InsertLocation } from './insertLocation';
 export * from './changeCase';
+export * from './html';
 export * as Events from './events';
+export { default as InsertLocation } from './insertLocation';
 export { default as numberToLetter } from './numberToLetter';
 export { default as uuid } from './uuid';
 
 const TEXT_CONTAINERS = ['HTML', 'JODIT_HTML', 'TIPTAP_HTML'];
 const blankRegex = /(@blank)/g;
-const htmlRegex = /(<\/?[^>]+(>|$))|&nbsp;/g;
 
 export const getMetaName = (type: string) => `meta-${kebabCase(type)}`;
 
@@ -32,5 +34,5 @@ export const getElementId = (element?: ContentElement | null) =>
 export const getQuestionPromptPreview = (elements: ContentElement[]) => {
   const textAssets = filter(elements, (it) => TEXT_CONTAINERS.includes(it.type));
   const questionText = map(textAssets, 'data.content').join(' ');
-  return questionText.replace(htmlRegex, '').replace(blankRegex, () => '____');
+  return htmlToText(questionText).replace(blankRegex, () => '____');
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -514,6 +514,9 @@ importers:
       hashids:
         specifier: ^2.3.0
         version: 2.3.0
+      html-entities:
+        specifier: ^2.6.0
+        version: 2.6.0
       humanize-string:
         specifier: ^3.1.0
         version: 3.1.0
@@ -1435,6 +1438,9 @@ importers:
       '@paralleldrive/cuid2':
         specifier: ^3.3.0
         version: 3.3.0
+      html-entities:
+        specifier: ^2.6.0
+        version: 2.6.0
       lodash-es:
         specifier: ^4.18.1
         version: 4.18.1


### PR DESCRIPTION
Closes #867 

Collapsed content elements showed raw HTML entities in their header preview. This PR adds a shared `htmlToText` helper in `packages/utils` (strip tags -> decode entities -> collapse whitespace).